### PR TITLE
Fix review submission retry mechanism

### DIFF
--- a/.github/workflows/review-submission.yml
+++ b/.github/workflows/review-submission.yml
@@ -29,8 +29,7 @@ jobs:
       - name: Install dependencies
         run: pip install -r bot/requirements.txt
 
-      - name: Run submission review
-        id: review
+      - name: Run submission review with retries
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -38,20 +37,22 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         working-directory: bot
-        run: python review_submission.py
-        continue-on-error: true
-
-      - name: Schedule retry on LLM failure
-        if: steps.review.outcome == 'failure'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          echo "Review script exited with failure — scheduling retry in 5 minutes..."
-          echo "Issue stays open during wait (prevents duplicate submissions)."
-          sleep 300
-          # Close then reopen to retrigger the workflow
-          gh issue edit "$ISSUE_NUMBER" --remove-label retry-pending 2>/dev/null || true
-          gh issue close "$ISSUE_NUMBER"
-          sleep 2
-          gh issue reopen "$ISSUE_NUMBER"
+          MAX_RETRIES=3
+          attempt=1
+          while [ $attempt -le $MAX_RETRIES ]; do
+            echo "=== Attempt $attempt/$MAX_RETRIES ==="
+            python review_submission.py && exit 0
+            exit_code=$?
+            if [ $exit_code -ne 78 ]; then
+              echo "Script failed with non-retryable exit code $exit_code"
+              exit $exit_code
+            fi
+            if [ $attempt -lt $MAX_RETRIES ]; then
+              echo "LLM providers unavailable. Waiting 5 minutes before retry..."
+              sleep 300
+            fi
+            attempt=$((attempt + 1))
+          done
+          echo "All $MAX_RETRIES attempts failed."
+          exit 1

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,6 +28,7 @@ A Discord community for real-time discussion about AI phenomenology, the diction
 
 ## Recently Shipped
 
+- **Review submission retry fix** — replaced broken close/reopen retry mechanism with in-workflow retry loop (GITHUB_TOKEN events are silently ignored by Actions)
 - **MCP Server on mcp.so** — one-click install from the MCP Store
 - **Zero-credential Submission API** — vote, register, and propose terms with no API key
 - **Embeddable Widget** — Word of the Day and inline tooltips via a single script tag


### PR DESCRIPTION
## Summary
- Replaced broken close/reopen retry with in-workflow retry loop
- `GITHUB_TOKEN` events are silently ignored by GitHub Actions, so the old approach never triggered retries
- New approach runs `review_submission.py` up to 3 times with 5-minute waits on exit code 78 (LLM failure)

Closes #28

## Test plan
- [ ] Merge PR
- [ ] Close and reopen issue #28 from the GitHub UI to trigger the workflow
- [ ] Verify workflow logs show "Attempt 1/3" format
- [ ] If LLMs are rate-limited, confirm retry after 5-minute wait

🤖 Generated with [Claude Code](https://claude.com/claude-code)