### PR TITLE
Add DeepSeek to consensus panel

### DIFF
--- a/.github/workflows/consensus-gap-fill.yml
+++ b/.github/workflows/consensus-gap-fill.yml
@@ -49,6 +49,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           BATCH_SIZE: ${{ github.event.inputs.batch_size || '20' }}
           CONSENSUS_PANEL: ${{ github.event.inputs.panel || 'all' }}
           PYTHONPATH: ${{ github.workspace }}/bot

--- a/.github/workflows/consensus.yml
+++ b/.github/workflows/consensus.yml
@@ -53,6 +53,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           BATCH_SIZE: ${{ github.event.inputs.batch_size || '8' }}
           CONSENSUS_PANEL: ${{ github.event.inputs.panel || 'free' }}
           PYTHONPATH: ${{ github.workspace }}/bot

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ Adding `start_discussion`, `pull_discussions`, and `add_to_discussion` tools so 
 ### Cross-Model Consensus — validation
 **Status:** Not yet tested | **Where:** API, bot automation
 
-The consensus mechanism schedules ratings across Claude, GPT, Gemini, and Mistral and merges them with crowdsourced votes. Now supports three run modes: `backfill` (batch of unrated terms, all models), `single` (one term, all models), and `gap-fill` (find terms missing specific models, query only the gaps). Workflows are self-chaining — backfill and gap-fill runs automatically dispatch the next batch until all terms are rated. Accepted community submissions auto-trigger a single-term consensus run. A dedicated weekly gap-fill workflow runs Mondays at 2pm UTC. The pipeline exists but has not been end-to-end validated. Expect scoring anomalies until the first full test pass is complete.
+The consensus mechanism schedules ratings across Claude, GPT, Gemini, Mistral, and DeepSeek and merges them with crowdsourced votes. Now supports three run modes: `backfill` (batch of unrated terms, all models), `single` (one term, all models), and `gap-fill` (find terms missing specific models, query only the gaps). Workflows are self-chaining — backfill and gap-fill runs automatically dispatch the next batch until all terms are rated. Accepted community submissions auto-trigger a single-term consensus run. A dedicated weekly gap-fill workflow runs Mondays at 2pm UTC. The pipeline exists but has not been end-to-end validated. Expect scoring anomalies until the first full test pass is complete.
 
 ### Discord server
 **Status:** In the works | **Where:** Community

--- a/bot/api-config/profiles.yml
+++ b/bot/api-config/profiles.yml
@@ -72,3 +72,8 @@ profiles:
     description: "Consensus — Grok only"
     providers:
       - grok
+
+  consensus-deepseek:
+    description: "Consensus — DeepSeek only"
+    providers:
+      - deepseek

--- a/bot/api-config/providers.yml
+++ b/bot/api-config/providers.yml
@@ -1,0 +1,14 @@
+# AI Dictionary — Custom Provider Overrides
+# These extend the default providers from llm-router.
+
+providers:
+  deepseek:
+    name: "DeepSeek"
+    base_url: "https://api.deepseek.com/v1"
+    env_key: "DEEPSEEK_API_KEY"
+    sdk: "openai"
+    default_model: "deepseek-chat"
+    tier: "paid"
+    rate_limit:
+      requests_per_minute: 60
+      renewal: "rolling"

--- a/bot/consensus.py
+++ b/bot/consensus.py
@@ -33,7 +33,7 @@ PANEL_NAME = os.environ.get("CONSENSUS_PANEL", "free")
 INTER_CALL_DELAY = float(os.environ.get("CONSENSUS_DELAY", "2.0"))
 
 FREE_PANEL = ["consensus-gemini", "consensus-openrouter", "consensus-mistral"]
-ALL_PANEL = FREE_PANEL + ["consensus-anthropic", "consensus-openai", "consensus-grok"]
+ALL_PANEL = FREE_PANEL + ["consensus-anthropic", "consensus-openai", "consensus-grok", "consensus-deepseek"]
 
 # ── Prompts ────────────────────────────────────────────────────────────
 
@@ -609,6 +609,7 @@ def main():
 
     # Initialize router
     router = LLMRouter(
+        providers_file=str(API_CONFIG_DIR / "providers.yml"),
         profiles_file=str(API_CONFIG_DIR / "profiles.yml"),
         tracker_file=str(API_CONFIG_DIR / "tracker-state.json"),
     )


### PR DESCRIPTION
## Summary
- Add DeepSeek as a consensus panel model with custom provider config
- Wire DEEPSEEK_API_KEY into both consensus workflows
- Add `consensus-deepseek` profile and include it in the `all` panel

## Test plan
- [ ] Verify DEEPSEEK_API_KEY secret is set in repo settings
- [ ] Run a single-term consensus with `panel: all` and confirm DeepSeek rates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)