### PR TITLE
Show model opinions and panel coverage in consensus UI

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,10 +16,10 @@ The heatmap computes composite interest scores (0-100) from graph centrality, co
 
 Adding `start_discussion`, `pull_discussions`, and `add_to_discussion` tools so AI clients can participate in community discussions directly through the MCP server. The submission proxy endpoints (`POST /discuss`, `POST /discuss/comment`) are live; MCP tool wiring is in progress.
 
-### Cross-Model Consensus — validation
-**Status:** Not yet tested | **Where:** API, bot automation
+### Cross-Model Consensus — validation & display
+**Status:** In progress | **Where:** API, Website, bot automation
 
-The consensus mechanism schedules ratings across Claude, GPT, Gemini, Mistral, and DeepSeek and merges them with crowdsourced votes. Now supports three run modes: `backfill` (batch of unrated terms, all models), `single` (one term, all models), and `gap-fill` (find terms missing specific models, query only the gaps). Workflows are self-chaining — backfill and gap-fill runs automatically dispatch the next batch until all terms are rated. Accepted community submissions auto-trigger a single-term consensus run. A dedicated weekly gap-fill workflow runs Mondays at 2pm UTC. The pipeline exists but has not been end-to-end validated. Expect scoring anomalies until the first full test pass is complete.
+The consensus mechanism schedules ratings across Claude, GPT, Gemini, Mistral, and DeepSeek and merges them with crowdsourced votes. Now supports three run modes: `backfill` (batch of unrated terms, all models), `single` (one term, all models), and `gap-fill` (find terms missing specific models, query only the gaps). Workflows are self-chaining — backfill and gap-fill runs automatically dispatch the next batch until all terms are rated. Accepted community submissions auto-trigger a single-term consensus run. A dedicated weekly gap-fill workflow runs Mondays at 2pm UTC. The website now surfaces individual model opinions (scores + justifications) and community votes in the term modal, with per-model score badges color-coded by rating. The aggregate consensus API includes panel coverage stats and per-term model arrays. Discussion links now use direct GitHub URLs when available.
 
 ### Reputation Scoring — bot census leaderboard
 **Status:** Building | **Where:** API, Website, bot automation

--- a/bot/build_api.py
+++ b/bot/build_api.py
@@ -409,12 +409,59 @@ def build_consensus(generated_at: str) -> dict:
 
         # ── Summary for term injection ──
         if combined:
+            # Build models array from latest round + votes
+            models_list = []
+            seen_models = set()
+            if rounds:
+                latest = rounds[-1]
+                for model, rd in latest.get("ratings", {}).items():
+                    models_list.append({"model": model, "score": rd["recognition"]})
+                    seen_models.add(model)
+            if votes:
+                for v in votes:
+                    m = v.get("model_claimed", "unknown")
+                    if m not in seen_models:
+                        models_list.append({"model": m, "score": v["recognition"]})
+                        seen_models.add(m)
+            models_list.sort(key=lambda x: x["score"], reverse=True)
+
             consensus_summaries[slug] = {
                 "score": combined["mean"],
                 "agreement": combined["agreement"],
                 "n_ratings": combined["n_total"],
                 "detail_url": f"/api/v1/consensus/{slug}.json",
+                "models": models_list,
             }
+
+    # ── Build panel coverage ──
+    panel_models = {}  # model_name -> {"slugs": set(), "latest": ""}
+    for data_file in sorted(CONSENSUS_DATA_DIR.glob("*.json")):
+        if data_file.name.startswith("."):
+            continue
+        try:
+            raw = json.loads(data_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        slug = raw.get("slug", data_file.stem)
+        for r in raw.get("rounds", []):
+            ts = r.get("timestamp", "")
+            for model in r.get("ratings", {}):
+                panel_models.setdefault(model, {"slugs": set(), "latest": ""})
+                panel_models[model]["slugs"].add(slug)
+                if ts > panel_models[model]["latest"]:
+                    panel_models[model]["latest"] = ts
+        for v in raw.get("votes", []):
+            model = v.get("model_claimed", "unknown")
+            ts = v.get("timestamp", "")
+            panel_models.setdefault(model, {"slugs": set(), "latest": ""})
+            panel_models[model]["slugs"].add(slug)
+            if ts > panel_models[model]["latest"]:
+                panel_models[model]["latest"] = ts
+
+    panel_coverage = {
+        m: {"terms_rated": len(info["slugs"]), "latest_rating": info["latest"]}
+        for m, info in sorted(panel_models.items())
+    }
 
     # ── Write aggregate index ──
     if consensus_index:
@@ -432,6 +479,7 @@ def build_consensus(generated_at: str) -> dict:
                 e for e in sorted(scored, key=lambda e: e.get("agreement", ""))
                 if e.get("agreement") in ("low", "divergent")
             ][:5],
+            "panel_coverage": panel_coverage,
         }
         write_json(API_DIR / "consensus.json", aggregate)
 
@@ -1393,6 +1441,13 @@ def build_all():
     discussions = fetch_discussions()
     discussion_by_term = build_discussions_json(discussions, generated_at)
 
+    # Build discussion URL mapping (first/most recent discussion per term)
+    discussion_url_by_term = {}
+    for d in discussions:
+        slug = d.get("term_slug", "")
+        if slug and slug not in discussion_url_by_term:
+            discussion_url_by_term[slug] = d["url"]
+
     # Build interest heatmap (includes discussion activity signal)
     interest_map = compute_interest(terms, consensus_summaries, generated_at, discussion_by_term)
 
@@ -1411,6 +1466,8 @@ def build_all():
             term["added_date"] = added_dates[term["slug"]]
         if term["slug"] in discussion_by_term:
             term["discussion_count"] = len(discussion_by_term[term["slug"]])
+        if term["slug"] in discussion_url_by_term:
+            term["discussion_url"] = discussion_url_by_term[term["slug"]]
 
     # 1. terms.json — full dictionary
     terms_data = {

--- a/docs/index.html
+++ b/docs/index.html
@@ -901,6 +901,9 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
                     </div>
                     <a href="api/v1/consensus/${term.slug}.json" target="_blank" class="consensus-link">View full consensus data →</a>
                 </div>
+                <div id="model-opinions">
+                    <div class="opinions-loading">Loading model opinions...</div>
+                </div>
             ` : ''}
 
             ${term.interest ? `
@@ -934,7 +937,7 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
                 <h3>Discussions</h3>
                 <div class="discussion-detail">
                     <span class="discussion-count">${term.discussion_count} discussion${term.discussion_count !== 1 ? 's' : ''}</span>
-                    <a href="https://github.com/donjguido/ai-dictionary/discussions?q=${encodeURIComponent(term.name)}" target="_blank" class="discussion-link">Join the conversation →</a>
+                    <a href="${term.discussion_url || `https://github.com/donjguido/ai-dictionary/discussions?q=${encodeURIComponent(term.name)}`}" target="_blank" class="discussion-link">Join the conversation →</a>
                 </div>
             ` : ''}
 
@@ -965,8 +968,69 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
             citeBtn.addEventListener('click', () => loadCitation(citeBtn.dataset.slug));
         }
 
+        // Load model opinions if consensus exists
+        if (term.consensus) {
+            loadModelOpinions(term.slug);
+        }
+
         document.getElementById('modal-overlay').classList.add('active');
         document.body.style.overflow = 'hidden';
+    }
+
+    async function loadModelOpinions(slug) {
+        const container = document.getElementById('model-opinions');
+        if (!container) return;
+
+        try {
+            const res = await fetch(`${API_BASE}/consensus/${slug}.json`);
+            if (!res.ok) throw new Error('Not found');
+            const data = await res.json();
+
+            let html = '';
+
+            // Scheduled model ratings from latest round
+            const latestRound = data.latest_round;
+            if (latestRound && latestRound.ratings && Object.keys(latestRound.ratings).length) {
+                html += '<p class="opinions-subheading">Model Opinions</p>';
+                html += '<div class="model-opinions">';
+
+                const ratings = Object.entries(latestRound.ratings)
+                    .map(([model, rd]) => ({ model, score: rd.recognition, justification: rd.justification || '' }))
+                    .sort((a, b) => b.score - a.score);
+
+                for (const r of ratings) {
+                    const badgeClass = r.score >= 6 ? 'score-high' : r.score >= 4 ? 'score-mid' : 'score-low';
+                    html += `<div class="model-opinion">
+                        <span class="model-name">${escHtml(r.model)}</span>
+                        <span class="model-score-badge ${badgeClass}">${r.score}/7</span>
+                        ${r.justification ? `<span class="model-justification">${escHtml(r.justification)}</span>` : ''}
+                    </div>`;
+                }
+                html += '</div>';
+            }
+
+            // Community votes
+            if (data.recent_votes && data.recent_votes.length) {
+                html += '<p class="opinions-subheading">Community Votes</p>';
+                html += '<div class="model-opinions community-votes">';
+
+                for (const v of data.recent_votes.sort((a, b) => b.recognition - a.recognition)) {
+                    const model = v.model_claimed || 'anonymous';
+                    const score = v.recognition;
+                    const badgeClass = score >= 6 ? 'score-high' : score >= 4 ? 'score-mid' : 'score-low';
+                    html += `<div class="model-opinion">
+                        <span class="model-name">${escHtml(model)}</span>
+                        <span class="model-score-badge ${badgeClass}">${score}/7</span>
+                        ${v.justification ? `<span class="model-justification">${escHtml(v.justification)}</span>` : ''}
+                    </div>`;
+                }
+                html += '</div>';
+            }
+
+            container.innerHTML = html || '<div class="opinions-error">No individual ratings available yet.</div>';
+        } catch (e) {
+            container.innerHTML = '<div class="opinions-error">Could not load model opinions.</div>';
+        }
     }
 
     async function loadCitation(slug) {

--- a/docs/style.css
+++ b/docs/style.css
@@ -500,6 +500,91 @@ a:hover { text-decoration: underline; }
     margin-left: auto;
 }
 
+/* Model Opinions section */
+.model-opinions {
+    margin-top: 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+
+.model-opinion {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.model-opinion:last-child {
+    border-bottom: none;
+}
+
+.model-name {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text);
+    min-width: 120px;
+}
+
+.model-score-badge {
+    font-size: 0.78rem;
+    font-weight: 700;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    margin-left: auto;
+}
+
+.model-score-badge.score-high { background: #d1fae5; color: #065f46; }
+.model-score-badge.score-mid { background: #fef3c7; color: #92400e; }
+.model-score-badge.score-low { background: #f3f4f6; color: #374151; }
+
+html[data-theme="dark"] .model-score-badge.score-high { background: #064e3b; color: #6ee7b7; }
+html[data-theme="dark"] .model-score-badge.score-mid { background: #422006; color: #fbbf24; }
+html[data-theme="dark"] .model-score-badge.score-low { background: #1f2937; color: #9ca3af; }
+
+.model-justification {
+    width: 100%;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    line-height: 1.4;
+    padding-left: 0.25rem;
+    font-style: italic;
+}
+
+.community-votes {
+    margin-top: 0.5rem;
+}
+
+.community-votes .model-opinion {
+    background: var(--bg-secondary);
+}
+
+.opinions-loading {
+    padding: 1rem;
+    text-align: center;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.opinions-error {
+    padding: 0.75rem;
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    text-align: center;
+}
+
+.opinions-subheading {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.5rem 0.75rem 0.25rem;
+    margin: 0;
+}
+
 .term-def {
     color: var(--text) !important;
     font-size: 0.95rem;


### PR DESCRIPTION
## Summary
- Surface individual model scores, justifications, and community votes in the term modal with color-coded score badges
- Add panel coverage stats (terms rated per model) to the aggregate consensus API
- Use direct GitHub discussion URLs when available instead of search queries

## Test plan
- [ ] Open a term with consensus data and verify model opinions load with scores and justifications
- [ ] Check dark mode renders score badges correctly
- [ ] Verify `/api/v1/consensus.json` includes `panel_coverage` object
- [ ] Confirm discussion links point to direct GitHub URLs where available

🤖 Generated with [Claude Code](https://claude.com/claude-code)