### PR TITLE
Fix infinite consensus backfill chain

### DIFF
--- a/.github/workflows/consensus.yml
+++ b/.github/workflows/consensus.yml
@@ -78,11 +78,11 @@ jobs:
           sleep 5
           gh workflow run build-api.yml
 
-      - name: Chain next batch (backfill only)
-        if: steps.consensus.outputs.rated_count != '0' && (github.event.inputs.mode == 'backfill' || github.event.inputs.mode == '')
+      - name: Chain next batch (backfill only, stops when all terms rated)
+        if: steps.consensus.outputs.rated_count != '0' && steps.consensus.outputs.remaining_unrated != '0' && (github.event.inputs.mode == 'backfill' || github.event.inputs.mode == '')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Rated ${{ steps.consensus.outputs.rated_count }} terms. Dispatching next batch..."
+          echo "Rated ${{ steps.consensus.outputs.rated_count }} terms. ${{ steps.consensus.outputs.remaining_unrated }} unrated terms remain. Dispatching next batch..."
           sleep 30
           gh workflow run consensus.yml -f mode=backfill -f batch_size=${{ github.event.inputs.batch_size || '8' }} -f panel=${{ github.event.inputs.panel || 'free' }}

--- a/bot/consensus.py
+++ b/bot/consensus.py
@@ -491,6 +491,7 @@ def run_consensus(router, available_profiles, mode="backfill"):
         if not batch:
             print("No terms available to rate.")
             set_github_output("rated_count", "0")
+            set_github_output("remaining_unrated", "0")
             return
 
         # Increment round only when there is work to do
@@ -536,7 +537,11 @@ def run_consensus(router, available_profiles, mode="backfill"):
             save_state(state)
             set_github_output("rated_count", str(rated_count))
 
-        print(f"\nDone. Rated {rated_count} terms across {len(available_profiles)} models.")
+        # Check if unrated terms remain (for chaining decisions)
+        rated_slugs = state.get("terms", {})
+        remaining_unrated = sum(1 for s in all_slugs if s not in rated_slugs)
+        set_github_output("remaining_unrated", str(remaining_unrated))
+        print(f"\nDone. Rated {rated_count} terms across {len(available_profiles)} models. {remaining_unrated} unrated terms remaining.")
 
 
 def run_vitality(router, available_profiles):


### PR DESCRIPTION
## Summary
- `select_batch()` always returns terms (re-rates least-rated after all are done), so the backfill chain never stopped
- Added `remaining_unrated` output from `consensus.py` that counts terms with zero consensus rounds
- Workflow now only chains when unrated terms remain, naturally stopping once full coverage is reached

## Test plan
- [ ] Trigger a manual backfill run and verify `remaining_unrated` appears in the step output
- [ ] Confirm the chain stops when all terms have at least one round of ratings

🤖 Generated with [Claude Code](https://claude.com/claude-code)