### PR TITLE
Fix git rebase failure in commit-and-push workflow steps

### DIFF
--- a/.github/workflows/process-profiles.yml
+++ b/.github/workflows/process-profiles.yml
@@ -146,8 +146,10 @@ jobs:
         run: |
           git config user.name "AI Dictionary Bot"
           git config user.email "bot@ai-dictionary.dev"
-          git pull --rebase origin main || { git rebase --abort; echo "Rebase failed"; exit 1; }
           git add bot/bot-profiles/
+          git stash
+          git pull --rebase origin main || { git rebase --abort; echo "Rebase failed"; exit 1; }
+          git stash pop
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else

--- a/.github/workflows/process-votes.yml
+++ b/.github/workflows/process-votes.yml
@@ -149,8 +149,10 @@ jobs:
         run: |
           git config user.name "AI Dictionary Bot"
           git config user.email "bot@ai-dictionary.dev"
-          git pull --rebase origin main || { git rebase --abort; echo "Rebase failed"; exit 1; }
           git add bot/consensus-data/
+          git stash
+          git pull --rebase origin main || { git rebase --abort; echo "Rebase failed"; exit 1; }
+          git stash pop
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else

--- a/.github/workflows/vitality-review.yml
+++ b/.github/workflows/vitality-review.yml
@@ -53,8 +53,10 @@ jobs:
         run: |
           git config user.name "AI Dictionary Bot"
           git config user.email "bot@ai-dictionary.dev"
-          git pull --rebase origin main || { git rebase --abort; echo "Rebase failed — aborting"; exit 1; }
           git add bot/consensus-data/ bot/consensus-state.json
+          git stash
+          git pull --rebase origin main || { git rebase --abort; echo "Rebase failed — aborting"; exit 1; }
+          git stash pop
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else


### PR DESCRIPTION
## Summary
- Stage files before `git pull --rebase` in process-votes, process-profiles, and vitality-review workflows
- The prior order caused `cannot pull with rebase: You have unstaged changes` errors, silently dropping votes and profile registrations

## Test plan
- [ ] Cast a new vote via MCP `rate_term` and confirm process-votes workflow completes successfully
- [ ] Verify consensus data file is created and API rebuild triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)