### PR TITLE
Fix auto-generated terms not triggering review pipeline

### DIFF
--- a/.github/workflows/generate-definitions.yml
+++ b/.github/workflows/generate-definitions.yml
@@ -62,6 +62,14 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: python bot/propose_generated_term.py
 
+      - name: Trigger review workflow
+        if: steps.propose.outputs.issue_number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run review-submission.yml \
+            -f issue_number=${{ steps.propose.outputs.issue_number }}
+
       - name: Commit rotation state
         if: steps.governor.outcome == 'success'
         run: |

--- a/.github/workflows/review-submission.yml
+++ b/.github/workflows/review-submission.yml
@@ -3,6 +3,12 @@ name: Review Community Submission
 on:
   issues:
     types: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to review'
+        required: true
+        type: number
 
 concurrency:
   group: review-submission
@@ -10,7 +16,9 @@ concurrency:
 
 jobs:
   review:
-    if: contains(github.event.issue.labels.*.name, 'community-submission')
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || contains(github.event.issue.labels.*.name, 'community-submission')
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -36,7 +44,7 @@ jobs:
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.inputs.issue_number }}
         working-directory: bot
         run: |
           MAX_RETRIES=3


### PR DESCRIPTION
GITHUB_TOKEN events don't spawn new workflow runs. Add workflow_dispatch trigger to review-submission.yml and have generate-definitions.yml explicitly call it after proposing a term.