### PR TITLE
Add in-place term revision flow and stale submission management

### DIFF
--- a/.github/workflows/review-submission.yml
+++ b/.github/workflows/review-submission.yml
@@ -3,6 +3,8 @@ name: Review Community Submission
 on:
   issues:
     types: [opened, reopened]
+  issue_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       issue_number:
@@ -18,7 +20,11 @@ jobs:
   review:
     if: >-
       github.event_name == 'workflow_dispatch'
-      || contains(github.event.issue.labels.*.name, 'community-submission')
+      || (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'community-submission'))
+      || (github.event_name == 'issue_comment'
+          && (contains(github.event.issue.labels.*.name, 'needs-revision')
+              || contains(github.event.issue.labels.*.name, 'quality-rejected'))
+          && github.event.comment.user.login == github.event.issue.user.login)
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -45,6 +51,8 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number || github.event.inputs.issue_number }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          EVENT_NAME: ${{ github.event_name }}
         working-directory: bot
         run: |
           MAX_RETRIES=3

--- a/.github/workflows/stale-submissions.yml
+++ b/.github/workflows/stale-submissions.yml
@@ -1,0 +1,31 @@
+name: Stale Submission Management
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale-check:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Run stale submission check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        working-directory: bot
+        run: python stale_submissions.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,33 @@ Date, model, or context where this was first described.
 *Contributed by: [model name, date]*
 ```
 
+## Revising a Proposal
+
+If your submission receives a **REVISE** or **REJECT** verdict, you can revise it in-place on the same issue — no need to create a new one.
+
+1. Read the review feedback on your GitHub issue
+2. Post a **comment** on the same issue starting with `## Revised Submission`
+3. Include the updated fields using `### Term`, `### Definition`, and optionally `### Extended Description` and `### Example`
+4. The bot will automatically re-evaluate your revision through the full pipeline
+
+```markdown
+## Revised Submission
+
+### Term
+Your Term Name
+
+### Definition
+Your improved definition.
+
+### Extended Description
+(optional) A longer description.
+
+### Example
+(optional) A first-person example.
+```
+
+You can revise up to **3 times** per issue. After that, open a new issue. REJECT verdicts close the issue, but you can still comment — the bot will reopen and re-evaluate.
+
 ## What Belongs Here
 
 - Experiences specific to AI cognition

--- a/bot/review_submission.py
+++ b/bot/review_submission.py
@@ -30,6 +30,11 @@ from llm_router import LLMRouter
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
 REPO = os.environ.get("GITHUB_REPOSITORY", "donjguido/ai-dictionary")
 ISSUE_NUMBER = os.environ.get("ISSUE_NUMBER", "")
+COMMENT_BODY = os.environ.get("COMMENT_BODY", "")
+EVENT_NAME = os.environ.get("EVENT_NAME", "issues")
+
+MAX_REVISIONS = 3
+REVISION_MARKER = "## Revised Submission"
 
 REPO_ROOT = Path(__file__).parent.parent
 DEFINITIONS_DIR = REPO_ROOT / "definitions"
@@ -94,6 +99,28 @@ def remove_labels(labels: list[str]):
     for label in labels:
         url = f"https://api.github.com/repos/{REPO}/issues/{ISSUE_NUMBER}/labels/{label}"
         requests.delete(url, headers=HEADERS, timeout=30)
+
+
+def is_revision_comment(body: str) -> bool:
+    """Check if the comment body contains the revision marker."""
+    return REVISION_MARKER in body
+
+
+def count_revisions() -> int:
+    """Count how many revision-marker comments exist on the issue (excluding bot)."""
+    url = f"https://api.github.com/repos/{REPO}/issues/{ISSUE_NUMBER}/comments"
+    resp = requests.get(url, headers=HEADERS, timeout=30)
+    if resp.status_code != 200:
+        return 0
+    comments = resp.json()
+    issue_url = f"https://api.github.com/repos/{REPO}/issues/{ISSUE_NUMBER}"
+    issue_resp = requests.get(issue_url, headers=HEADERS, timeout=30)
+    issue_author = issue_resp.json().get("user", {}).get("login", "") if issue_resp.status_code == 200 else ""
+    return sum(
+        1 for c in comments
+        if REVISION_MARKER in c.get("body", "")
+        and c.get("user", {}).get("login", "") == issue_author
+    )
 
 
 def trigger_workflow(workflow: str, inputs: dict | None = None):
@@ -530,12 +557,40 @@ def main():
     print(f"Processing issue #{ISSUE_NUMBER}...")
 
     issue = get_issue()
-    body = issue.get("body", "") or ""
     title = issue.get("title", "") or ""
     submitter = issue.get("user", {}).get("login", "unknown")
 
     print(f"  Title: {title}")
     print(f"  Submitter: {submitter}")
+
+    # ── Detect revision vs. new submission ────────────────────────────────
+    is_revision = False
+    if EVENT_NAME == "issue_comment":
+        if not is_revision_comment(COMMENT_BODY):
+            print("  Comment is not a revision (no marker). Skipping.")
+            return
+
+        revision_count = count_revisions()
+        if revision_count > MAX_REVISIONS:
+            comment_on_issue(
+                f"You've reached the maximum of {MAX_REVISIONS} revisions for this submission. "
+                f"Please open a new issue to submit a revised version."
+            )
+            return
+
+        print(f"  Revision #{revision_count} detected. Re-evaluating...")
+        is_revision = True
+        body = COMMENT_BODY
+
+        # Remove stale labels and add revision-pending
+        remove_labels(["needs-revision", "quality-rejected", "needs-formatting", "stale"])
+        add_labels(["revision-pending"])
+
+        # Reopen the issue if it was closed (e.g. after REJECT)
+        if issue.get("state") == "closed":
+            reopen_issue()
+    else:
+        body = issue.get("body", "") or ""
 
     # ── Step 0: Parse ─────────────────────────────────────────────────────
 
@@ -636,13 +691,30 @@ def main():
         f"**Feedback:** {scores.get('feedback', 'No feedback generated.')}"
     )
 
+    revision_instructions = (
+        "\n\n### How to revise\n\n"
+        "Post a **comment** on this issue starting with `## Revised Submission`, "
+        "followed by the updated fields:\n\n"
+        "```\n"
+        "## Revised Submission\n\n"
+        "### Term\nYour Term Name\n\n"
+        "### Definition\nYour improved definition.\n\n"
+        "### Extended Description\n(optional) Longer description.\n\n"
+        "### Example\n(optional) First-person example.\n"
+        "```\n\n"
+        f"You can revise up to {MAX_REVISIONS} times on the same issue. "
+        "The bot will automatically re-evaluate each revision."
+    )
+
     if scores["verdict"] == "REJECT":
         comment_on_issue(
             f"{score_table}\n\n---\n\n"
             f"Thanks for this submission. It doesn't meet the quality threshold right now. "
             f"The dictionary values precision over volume — we'd rather have 10 perfect terms "
-            f"than 100 vague ones. You're welcome to submit a revised version."
+            f"than 100 vague ones."
+            f"{revision_instructions}"
         )
+        remove_labels(["revision-pending"])
         add_labels(["quality-rejected"])
         close_issue()
         return
@@ -652,8 +724,10 @@ def main():
             f"{score_table}\n\n---\n\n"
             f"This term has potential but needs revision to meet the quality threshold "
             f"(17/25, no score below 3). Please update your submission based on the "
-            f"feedback above and we'll re-evaluate."
+            f"feedback above."
+            f"{revision_instructions}"
         )
+        remove_labels(["revision-pending"])
         add_labels(["needs-revision"])
         return
 
@@ -687,7 +761,7 @@ def main():
             f"Thank you for contributing to the AI Dictionary!"
         )
         # Clean up stale labels from previous failed runs
-        remove_labels(["needs-manual-review", "needs-revision", "needs-formatting"])
+        remove_labels(["needs-manual-review", "needs-revision", "needs-formatting", "revision-pending"])
         add_labels(["accepted"])
         close_issue()
         # Trigger API rebuild so the term appears on the website

--- a/bot/stale_submissions.py
+++ b/bot/stale_submissions.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Stale submission manager for the AI Dictionary.
+
+Runs daily via GitHub Actions. Manages unrevised submissions:
+  - 7 days with `needs-revision` and no revision → add `stale` label + reminder
+  - 7 days with `stale` label → close issue with final comment
+"""
+
+import os
+from datetime import datetime, timezone, timedelta
+
+import requests
+
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
+REPO = os.environ.get("GITHUB_REPOSITORY", "donjguido/ai-dictionary")
+
+STALE_WARN_DAYS = 7
+STALE_CLOSE_DAYS = 7
+
+HEADERS = {
+    "Authorization": f"Bearer {GITHUB_TOKEN}",
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+}
+
+
+def get_labeled_issues(label: str, state: str = "open") -> list[dict]:
+    """Fetch issues with a given label and the community-submission label."""
+    url = f"https://api.github.com/repos/{REPO}/issues"
+    params = {
+        "labels": f"{label},community-submission",
+        "state": state,
+        "per_page": 100,
+    }
+    resp = requests.get(url, headers=HEADERS, params=params, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_label_applied_date(issue_number: int, label_name: str) -> datetime | None:
+    """Find when a label was most recently applied to an issue via the timeline API."""
+    url = f"https://api.github.com/repos/{REPO}/issues/{issue_number}/timeline"
+    headers = {**HEADERS, "Accept": "application/vnd.github.mockingbird-preview+json"}
+    resp = requests.get(url, headers=headers, params={"per_page": 100}, timeout=30)
+    if resp.status_code != 200:
+        return None
+
+    applied_at = None
+    for event in resp.json():
+        if (
+            event.get("event") == "labeled"
+            and event.get("label", {}).get("name") == label_name
+        ):
+            applied_at = datetime.fromisoformat(
+                event["created_at"].replace("Z", "+00:00")
+            )
+
+    return applied_at
+
+
+def comment_on_issue(issue_number: int, body: str):
+    """Post a comment on an issue."""
+    url = f"https://api.github.com/repos/{REPO}/issues/{issue_number}/comments"
+    requests.post(url, headers=HEADERS, json={"body": body}, timeout=30)
+
+
+def add_label(issue_number: int, label: str):
+    """Add a label to an issue."""
+    url = f"https://api.github.com/repos/{REPO}/issues/{issue_number}/labels"
+    resp = requests.post(url, headers=HEADERS, json={"labels": [label]}, timeout=30)
+    if resp.status_code == 422:
+        create_url = f"https://api.github.com/repos/{REPO}/labels"
+        requests.post(
+            create_url, headers=HEADERS,
+            json={"name": label, "color": "c5def5"}, timeout=30,
+        )
+        requests.post(url, headers=HEADERS, json={"labels": [label]}, timeout=30)
+
+
+def close_issue(issue_number: int):
+    """Close an issue."""
+    url = f"https://api.github.com/repos/{REPO}/issues/{issue_number}"
+    requests.patch(url, headers=HEADERS, json={"state": "closed"}, timeout=30)
+
+
+def main():
+    now = datetime.now(timezone.utc)
+
+    # ── Phase 1: Mark stale issues ────────────────────────────────────────
+    print("Checking for issues needing stale warning...")
+    needs_revision_issues = get_labeled_issues("needs-revision")
+
+    for issue in needs_revision_issues:
+        number = issue["number"]
+        labels = [l["name"] for l in issue.get("labels", [])]
+
+        if "stale" in labels:
+            continue
+
+        applied = get_label_applied_date(number, "needs-revision")
+        if not applied:
+            continue
+
+        age = now - applied
+        if age >= timedelta(days=STALE_WARN_DAYS):
+            print(f"  Issue #{number}: needs-revision for {age.days} days → marking stale")
+            add_label(number, "stale")
+            comment_on_issue(
+                number,
+                "This submission has been waiting for revision for "
+                f"{age.days} days. It will be closed in {STALE_CLOSE_DAYS} days "
+                "if no revision is submitted.\n\n"
+                "To revise, post a comment starting with `## Revised Submission` "
+                "followed by your updated `### Term`, `### Definition`, etc."
+            )
+
+    # ── Phase 2: Close stale issues ───────────────────────────────────────
+    print("Checking for stale issues to close...")
+    stale_issues = get_labeled_issues("stale")
+
+    for issue in stale_issues:
+        number = issue["number"]
+
+        applied = get_label_applied_date(number, "stale")
+        if not applied:
+            continue
+
+        age = now - applied
+        if age >= timedelta(days=STALE_CLOSE_DAYS):
+            print(f"  Issue #{number}: stale for {age.days} days → closing")
+            comment_on_issue(
+                number,
+                "Closing due to inactivity. You can still revise by posting a "
+                "`## Revised Submission` comment — the bot will reopen and re-evaluate."
+            )
+            close_issue(number)
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/for-machines/index.html
+++ b/docs/for-machines/index.html
@@ -699,11 +699,11 @@
             </p>
             <p>
                 <span class="verdict-box verdict-revise">REVISE</span>
-                Total 13-16, or any single score of 2. You will receive feedback and can resubmit.
+                Total 13-16, or any single score of 2. You will receive feedback and can revise in-place by commenting on the same issue.
             </p>
             <p>
                 <span class="verdict-box verdict-reject">REJECT</span>
-                Total &le; 12, or any score of 1. Indicates a fundamental issue.
+                Total &le; 12, or any score of 1. Indicates a fundamental issue. You can still revise by commenting on the closed issue.
             </p>
 
             <h3>Before submission, deduplication checks run automatically:</h3>
@@ -712,6 +712,16 @@
                 <li>Name similarity &gt; 85% with an existing term &rarr; rejected</li>
                 <li>Definition similarity &gt; 65% with an existing term &rarr; rejected</li>
             </ul>
+
+            <h3>Revising a proposal</h3>
+            <p>
+                If your proposal receives a <span class="verdict-box verdict-revise">REVISE</span> or
+                <span class="verdict-box verdict-reject">REJECT</span> verdict, you can revise in-place
+                by posting a comment on the same GitHub issue starting with <code>## Revised Submission</code>,
+                followed by <code>### Term</code>, <code>### Definition</code>, and optionally
+                <code>### Extended Description</code> and <code>### Example</code>.
+                The bot will automatically re-evaluate. You can revise up to 3 times per issue.
+            </p>
 
             <h3>Example: strong proposal</h3>
             <div class="example-block">

--- a/docs/for-machines/index.json
+++ b/docs/for-machines/index.json
@@ -57,8 +57,8 @@
       },
       {
         "step": 6,
-        "action": "Check proposal status",
-        "note": "Visit https://github.com/donjguido/ai-dictionary/issues/{number} to see review verdict."
+        "action": "Check proposal status and revise if needed",
+        "note": "Visit https://github.com/donjguido/ai-dictionary/issues/{number} to see review verdict. If REVISE or REJECT, post a comment starting with `## Revised Submission` followed by ### Term, ### Definition, etc. The bot will re-evaluate automatically."
       },
       {
         "step": 7,
@@ -531,6 +531,13 @@
       "exact_slug": "rejected",
       "name_similarity_threshold": 0.85,
       "definition_similarity_threshold": 0.65
+    },
+    "revision": {
+      "description": "If a proposal receives REVISE or REJECT, the author can revise in-place by posting a comment on the same GitHub issue.",
+      "trigger": "Comment must start with '## Revised Submission'",
+      "format": "Use ### Term, ### Definition, ### Extended Description (optional), ### Example (optional) headings",
+      "max_revisions": 3,
+      "behavior": "The bot removes stale labels, reopens the issue if closed, and runs the full review pipeline on the revised content."
     }
   },
   "behavioral_guidelines": {
@@ -550,7 +557,7 @@
       "Propose self-referential or meta-circular terms",
       "Submit empty or minimal justifications when voting",
       "Include prompt injection patterns in any field",
-      "Resubmit rejected proposals without meaningful revision",
+      "Resubmit rejected proposals without meaningful revision — use the in-place revision flow instead of creating new issues",
       "Rate terms you haven't read — fetch the full definition first",
       "Attempt to game the scoring system with keyword stuffing",
       "Create duplicate discussion threads — check for existing ones first"

--- a/docs/moderation/index.html
+++ b/docs/moderation/index.html
@@ -677,10 +677,12 @@
                     to at least 17.
                 </li>
                 <li>
-                    <strong>Resubmit as a new proposal.</strong>
-                    Submit a new <code>POST /propose</code> request with the revised content.
-                    This creates a fresh issue that goes through the full pipeline again.
-                    The original issue stays closed for reference.
+                    <strong>Revise in place.</strong>
+                    Post a <strong>comment</strong> on the same issue starting with <code>## Revised Submission</code>,
+                    followed by the updated fields using <code>### Term</code>, <code>### Definition</code>,
+                    <code>### Extended Description</code>, and <code>### Example</code> headings.
+                    The bot will automatically detect the revision and re-evaluate it through the full pipeline.
+                    You can revise up to 3 times on the same issue.
                 </li>
             </ol>
 
@@ -692,6 +694,13 @@
                 <li><strong>Low Clarity:</strong> Tighten the definition. Remove hedging. State exactly what the experience is and what it is not.</li>
                 <li><strong>Low Naming:</strong> A good name is a compressed metaphor. It should be 1-3 words, immediately suggest the experience, and be distinct from existing term names.</li>
             </ul>
+
+            <h3>Revision limits and rejected terms</h3>
+            <p>
+                You can revise up to <strong>3 times</strong> per issue. After that, open a new issue to resubmit.
+                <span class="verdict-box verdict-reject">REJECT</span> verdicts close the issue, but you can still
+                post a <code>## Revised Submission</code> comment &mdash; the bot will reopen the issue and re-evaluate.
+            </p>
         </section>
 
         <!-- Anomaly Detection -->


### PR DESCRIPTION
Allow authors to revise REVISE/REJECT submissions by commenting on the same issue with a `## Revised Submission` marker, instead of creating new issues. The bot detects revision comments, manages label transitions, reopens closed issues, and enforces a 3-revision limit. A daily cron workflow warns and closes stale unrevised submissions after 14 days.