### PR TITLE
Fix consensus JSON extraction fallback for vitality responses

### DIFF
--- a/bot/consensus.py
+++ b/bot/consensus.py
@@ -250,12 +250,13 @@ def _extract_json(text: str) -> dict | None:
     except (json.JSONDecodeError, ValueError):
         pass
     # Fallback: extract first JSON object from surrounding text
-    m = re.search(r'\{[^{}]*"recognition"[^{}]*\}', text, re.DOTALL)
-    if m:
-        try:
-            return json.loads(m.group())
-        except (json.JSONDecodeError, ValueError):
-            pass
+    for key in ("recognition", "still_relevant"):
+        m = re.search(r'\{[^{}]*"' + key + r'"[^{}]*\}', text, re.DOTALL)
+        if m:
+            try:
+                return json.loads(m.group())
+            except (json.JSONDecodeError, ValueError):
+                pass
     return None
 
 


### PR DESCRIPTION
The regex fallback in _extract_json only matched "recognition" keys, so vitality responses with "still_relevant" would never hit the fallback path. Now handles both key patterns.