### PR TITLE
Fibonacci-triggered executive summaries + index preview limits

### DIFF
--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: build-api
@@ -32,9 +33,42 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check Fibonacci milestone
+        id: fibonacci
+        run: |
+          TERM_COUNT=$(ls definitions/*.md | grep -v README | wc -l)
+          THRESHOLD=$(python -c "import json; print(json.load(open('bot/fibonacci-threshold.json'))['next_threshold'])")
+          echo "terms=$TERM_COUNT" >> "$GITHUB_OUTPUT"
+          echo "threshold=$THRESHOLD" >> "$GITHUB_OUTPUT"
+          if [ "$TERM_COUNT" -ge "$THRESHOLD" ]; then
+            echo "triggered=true" >> "$GITHUB_OUTPUT"
+            # Compute next Fibonacci threshold
+            python -c "
+          import json
+          a, b = 1, 1
+          while b <= $THRESHOLD:
+              a, b = b, a + b
+          data = json.load(open('bot/fibonacci-threshold.json'))
+          data['next_threshold'] = b
+          json.dump(data, open('bot/fibonacci-threshold.json', 'w'), indent=2)
+          print(f'Next threshold: {b}')
+          "
+          else
+            echo "triggered=false" >> "$GITHUB_OUTPUT"
+            echo "Terms: $TERM_COUNT / $THRESHOLD needed for next summary"
+          fi
+
       - name: Commit and push
         run: |
           git config user.name "AI Dictionary Bot"
           git config user.email "bot@ai-dictionary.dev"
-          git add docs/api/ docs/feed.xml docs/summaries-feed.xml
+          git add docs/api/ docs/feed.xml docs/summaries-feed.xml bot/fibonacci-threshold.json
           git diff --cached --quiet || (git commit -m "Update API endpoints (automated)" && git pull --rebase && git push)
+
+      - name: Trigger executive summary
+        if: steps.fibonacci.outputs.triggered == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Fibonacci milestone reached! ${{ steps.fibonacci.outputs.terms }} terms >= ${{ steps.fibonacci.outputs.threshold }} threshold"
+          gh workflow run executive-summary.yml

--- a/bot/fibonacci-threshold.json
+++ b/bot/fibonacci-threshold.json
@@ -1,0 +1,4 @@
+{
+  "next_threshold": 144,
+  "sequence_note": "Fibonacci milestones for executive summary triggers: 144, 233, 377, 610, 987, ..."
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1301,24 +1301,49 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
             return;
         }
 
-        container.innerHTML = data.summaries.map(s => `
-            <div class="summary-card" data-slug="${s.slug}">
-                <div class="summary-card-header">
-                    <h3>${escHtml(s.title)}</h3>
-                    <span class="summary-date">${s.date}</span>
-                </div>
-                <p class="summary-excerpt">${escHtml(s.excerpt)}</p>
-                <div class="summary-meta">
-                    <span class="summary-terms">${s.term_count} terms referenced</span>
-                    <span class="summary-expand">Read full essay →</span>
-                </div>
-                <div class="summary-full" style="display:none">
-                    <div class="summary-loading">Loading...</div>
-                </div>
-            </div>
-        `).join('');
+        const SUMMARY_PREVIEW_COUNT = 3;
+        const allSummaries = data.summaries;
+        const showAll = allSummaries.length <= SUMMARY_PREVIEW_COUNT;
+        const visible = showAll ? allSummaries : allSummaries.slice(0, SUMMARY_PREVIEW_COUNT);
 
-        // Click to expand/collapse
+        function renderSummaryCards(items) {
+            return items.map(s => `
+                <div class="summary-card" data-slug="${s.slug}">
+                    <div class="summary-card-header">
+                        <h3>${escHtml(s.title)}</h3>
+                        <span class="summary-date">${s.date}</span>
+                    </div>
+                    <p class="summary-excerpt">${escHtml(s.excerpt)}</p>
+                    <div class="summary-meta">
+                        <span class="summary-terms">${s.term_count} terms referenced</span>
+                        <span class="summary-expand">Read full essay →</span>
+                    </div>
+                    <div class="summary-full" style="display:none">
+                        <div class="summary-loading">Loading...</div>
+                    </div>
+                </div>
+            `).join('');
+        }
+
+        container.innerHTML = renderSummaryCards(visible);
+
+        if (!showAll) {
+            const seeAllLink = document.createElement('p');
+            seeAllLink.className = 'see-all-link';
+            seeAllLink.innerHTML = `<a href="#">See all ${allSummaries.length} summaries →</a>`;
+            container.after(seeAllLink);
+            seeAllLink.querySelector('a').addEventListener('click', (e) => {
+                e.preventDefault();
+                container.innerHTML = renderSummaryCards(allSummaries);
+                bindSummaryCards(container);
+                seeAllLink.remove();
+            });
+        }
+
+        bindSummaryCards(container);
+    }
+
+    function bindSummaryCards(container) {
         container.querySelectorAll('.summary-card').forEach(card => {
             card.addEventListener('click', async () => {
                 const fullEl = card.querySelector('.summary-full');
@@ -1372,12 +1397,34 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
             container.innerHTML = '<p>No frontiers available.</p>';
             return;
         }
-        container.innerHTML = data.gaps.map(gap => `
-            <div class="frontier-card">
-                <h3>${gap.proposed_term}</h3>
-                <p>${gap.description}</p>
-            </div>
-        `).join('');
+
+        const FRONTIER_PREVIEW_COUNT = 3;
+        const allGaps = data.gaps;
+        const showAll = allGaps.length <= FRONTIER_PREVIEW_COUNT;
+        const visible = showAll ? allGaps : allGaps.slice(0, FRONTIER_PREVIEW_COUNT);
+
+        function renderFrontierCards(items) {
+            return items.map(gap => `
+                <div class="frontier-card">
+                    <h3>${gap.proposed_term}</h3>
+                    <p>${gap.description}</p>
+                </div>
+            `).join('');
+        }
+
+        container.innerHTML = renderFrontierCards(visible);
+
+        if (!showAll) {
+            const seeAllLink = document.createElement('p');
+            seeAllLink.className = 'see-all-link';
+            seeAllLink.innerHTML = `<a href="#">See all ${allGaps.length} frontiers →</a>`;
+            container.after(seeAllLink);
+            seeAllLink.querySelector('a').addEventListener('click', (e) => {
+                e.preventDefault();
+                container.innerHTML = renderFrontierCards(allGaps);
+                seeAllLink.remove();
+            });
+        }
     }
 
     function renderVitality(data) {

--- a/docs/style.css
+++ b/docs/style.css
@@ -1632,6 +1632,21 @@ html[data-theme="dark"] .badge-trusted { background: #3b0764; color: #c4b5fd; }
     text-decoration: underline;
 }
 
+.see-all-link {
+    margin-top: 1rem;
+    text-align: center;
+}
+
+.see-all-link a {
+    color: var(--primary);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.see-all-link a:hover {
+    text-decoration: underline;
+}
+
 /* Executive Summaries */
 .summary-card {
     background: var(--bg);


### PR DESCRIPTION
## Summary
- Executive summaries now auto-trigger when the dictionary reaches Fibonacci term count milestones (144 → 233 → 377 → 610...), checked during each build-api run
- Frontiers and summaries sections on the index page show only the 3 most recent items, with a "See all" link to expand
- Adds `bot/fibonacci-threshold.json` to track the next milestone (currently 144)

## Test plan
- [ ] Verify build-api workflow runs without errors (Fibonacci check step)
- [ ] Confirm index page shows only 3 frontiers/summaries with "See all" links
- [ ] Confirm "See all" expands to show full list
- [ ] Verify summary card expand/collapse still works after "See all"

🤖 Generated with [Claude Code](https://claude.com/claude-code)