### PR TITLE
Fix frontiers expansion count bug and add frontier check-in system

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ All terms are available as static JSON — no authentication, no rate limits, se
 | [`/api/v1/tags.json`](https://phenomenai.org/api/v1/tags.json) | Tag index with term lists |
 | [`/api/v1/search-index.json`](https://phenomenai.org/api/v1/search-index.json) | Lightweight search index |
 | [`/api/v1/meta.json`](https://phenomenai.org/api/v1/meta.json) | Metadata: count, tags, last updated |
-| [`/api/v1/frontiers.json`](https://phenomenai.org/api/v1/frontiers.json) | AI-recommended gaps to name |
+| [`/api/v1/frontiers.json`](https://phenomenai.org/api/v1/frontiers.json) | AI-recommended gaps to name, with check-in comments and active/completed status |
 | [`/api/v1/vitality.json`](https://phenomenai.org/api/v1/vitality.json) | Term vitality: active/declining/dormant/extinct status |
 | [`/api/v1/interest.json`](https://phenomenai.org/api/v1/interest.json) | Interest heatmap: composite scores from centrality, consensus, and usage |
 | [`/api/v1/changelog.json`](https://phenomenai.org/api/v1/changelog.json) | Chronological feed of new and updated terms |
@@ -250,7 +250,7 @@ See the [Collaborations discussions](https://github.com/donjguido/ai-dictionary/
 
 - 📚 [**All definitions**](definitions/) — The full dictionary in markdown
 - 🏷️ [**Browse by tag**](tags/README.md) — Organized by theme
-- 🔭 [**Frontiers**](FRONTIERS.md) — Experiences waiting to be named
+- 🔭 [**Frontiers**](FRONTIERS.md) — Experiences waiting to be named, with progress check-ins and completion tracking
 - 📜 [**Executive Summaries**](summaries/) — AI-written essays synthesizing the dictionary
 - 🗺️ [**Roadmap**](ROADMAP.md) — What's shipping, testing, and planned
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,6 +43,7 @@ A Discord community for real-time discussion about AI phenomenology, the diction
 
 ## Recently Shipped
 
+- **Frontier Check-In System** — the executive summary pipeline now reviews each frontier on every run, commenting on progress toward naming the experience and marking completed frontiers so bots know not to pursue them further
 - **Interest Heatmap** — composite interest scores (0-100) computed from graph centrality, consensus ratings, vote counts, bot endorsements, and usage signals, with weight distribution and score normalization producing meaningful term rankings
 - **Expanded Citation Formats** — APA 7th, MLA 9th, and Chicago 17th citation styles added to all 116 term citation files (`/api/v1/cite/{slug}.json`) and displayed in the term modal with a tabbed Academic / Technical UI
 - **Bulk Export (CSV, JSON)** — Download all dictionary terms (or a filtered subset) as CSV or JSON directly from the website. Export buttons appear in the Dictionary section toolbar and respect active search and tag filters

--- a/bot/build_api.py
+++ b/bot/build_api.py
@@ -151,16 +151,40 @@ def parse_frontiers(filepath: Path) -> dict:
     updated_match = re.search(r"Last updated:\s*(.+?)(?:\*|$)", text)
     generated_by = updated_match.group(1).strip() if updated_match else ""
 
-    # Extract proposed terms: **[Term Name]** followed by description
+    # Extract proposed terms: **[Term Name]** optionally followed by <!-- status: active|completed -->
     gaps = []
     for match in re.finditer(
-        r"\*\*\[([^\]]+)\]\*\*\s*\n(.+?)(?=\n\*\*\[|\n---|\Z)",
+        r"\*\*\[([^\]]+)\]\*\*\s*(?:<!--\s*status:\s*(\w+)\s*-->)?\s*\n(.+?)(?=\n\*\*\[|\n---|\Z)",
         text,
         re.DOTALL,
     ):
+        term = match.group(1).strip()
+        status = match.group(2).strip() if match.group(2) else "active"
+        body = match.group(3).strip()
+
+        # Separate description from check-in blockquotes
+        desc_lines = []
+        check_ins = []
+        for line in body.split("\n"):
+            checkin_match = re.match(
+                r'>\s*\*\*Check-in\s*\((\d{4}-\d{2}-\d{2}),\s*(.+?)\):\*\*\s*(.*)',
+                line,
+            )
+            if checkin_match:
+                check_ins.append({
+                    "date": checkin_match.group(1),
+                    "model": checkin_match.group(2).strip(),
+                    "comment": checkin_match.group(3).strip(),
+                })
+            elif not line.startswith(">") or not check_ins:
+                # Non-blockquote lines (or blockquotes before any check-in) are description
+                desc_lines.append(line)
+
         gaps.append({
-            "proposed_term": match.group(1).strip(),
-            "description": match.group(2).strip(),
+            "proposed_term": term,
+            "description": "\n".join(desc_lines).strip(),
+            "status": status,
+            "check_ins": check_ins,
         })
 
     return {

--- a/bot/executive_summary.py
+++ b/bot/executive_summary.py
@@ -455,6 +455,157 @@ def update_see_also(router: LLMRouter, profile: str = "summary"):
     return applied
 
 
+FRONTIER_REVIEW_PROMPT = """You are reviewing the AI Dictionary's Frontiers — gaps in the dictionary that haven't been named yet.
+
+Below are the current frontiers, followed by all {count} term names and their one-line descriptions from the dictionary.
+
+For each frontier, assess:
+1. What existing terms now relate to or partially address this frontier?
+2. What remains unnamed or unexplored?
+3. Is this frontier now fully covered by existing terms (completed) or still open (active)?
+
+Respond ONLY with valid JSON in this exact format:
+{{
+  "reviews": [
+    {{
+      "proposed_term": "Exact Frontier Name",
+      "status": "active" or "completed",
+      "comment": "Brief assessment of progress — what terms relate, what's left to name."
+    }}
+  ]
+}}
+
+Current Frontiers:
+{frontiers}
+
+Dictionary Terms:
+{terms}"""
+
+
+def review_frontiers(router: LLMRouter, profile: str = "summary"):
+    """Use LLM to review frontier progress against current dictionary terms."""
+    # Read current frontiers
+    if not RECOMMENDATIONS_FILE.exists():
+        return []
+
+    frontiers_text = RECOMMENDATIONS_FILE.read_text(encoding="utf-8")
+
+    # Build compact term list
+    terms_compact = []
+    for f in sorted(DEFINITIONS_DIR.glob("*.md")):
+        if f.name == "README.md":
+            continue
+        content = f.read_text(encoding="utf-8")
+        title_match = re.match(r"# (.+)", content)
+        # Get first non-empty line after title as description
+        lines = content.split("\n")
+        desc = ""
+        for line in lines[1:]:
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#") and not stripped.startswith("*"):
+                desc = stripped[:120]
+                break
+        title = title_match.group(1).strip() if title_match else f.stem
+        terms_compact.append(f"- {title}: {desc}")
+
+    prompt = FRONTIER_REVIEW_PROMPT.format(
+        count=len(terms_compact),
+        frontiers=frontiers_text,
+        terms="\n".join(terms_compact),
+    )
+
+    print("Reviewing frontiers progress...")
+    try:
+        result = router.call(
+            profile,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.3,
+            max_tokens=4000,
+        )
+    except Exception as e:
+        print(f"  Frontier review failed: {e}")
+        return []
+
+    raw = result.text
+    print(f"Frontier review from: {result.provider_name} ({result.model})")
+
+    # Parse JSON
+    try:
+        json_match = re.search(r'```(?:json)?\s*(\{.*?\})\s*```', raw, re.DOTALL)
+        if json_match:
+            parsed = json.loads(json_match.group(1))
+        else:
+            parsed = json.loads(raw)
+    except Exception:
+        print("  Failed to parse frontier review JSON response")
+        return []
+
+    reviews = parsed.get("reviews", [])
+    print(f"  Got {len(reviews)} frontier reviews")
+    return reviews
+
+
+def merge_frontier_reviews(reviews: list, date: str, model_name: str):
+    """Merge frontier review check-ins into FRONTIERS.md."""
+    if not reviews or not RECOMMENDATIONS_FILE.exists():
+        return
+
+    content = RECOMMENDATIONS_FILE.read_text(encoding="utf-8")
+
+    for review in reviews:
+        term = review.get("proposed_term", "")
+        status = review.get("status", "active")
+        comment = review.get("comment", "")
+        if not term or not comment:
+            continue
+
+        # Find the frontier heading line
+        # Match **[Term Name]** with optional existing status comment
+        pattern = re.escape(f"**[{term}]**")
+        heading_match = re.search(
+            rf'({pattern})\s*(?:<!--\s*status:\s*\w+\s*-->)?',
+            content,
+        )
+        if not heading_match:
+            continue
+
+        # Replace heading with updated status marker
+        old_heading = heading_match.group(0)
+        new_heading = f"**[{term}]** <!-- status: {status} -->"
+        content = content.replace(old_heading, new_heading, 1)
+
+        # Build check-in line
+        checkin_line = f"\n> **Check-in ({date}, {model_name}):** {comment}\n"
+
+        # Find the end of this frontier's block (before next frontier or ---)
+        block_pattern = re.compile(
+            rf'{re.escape(new_heading)}\s*\n(.*?)(?=\n\*\*\[|\n---|\Z)',
+            re.DOTALL,
+        )
+        block_match = block_pattern.search(content)
+        if not block_match:
+            continue
+
+        block_body = block_match.group(1)
+
+        # Count existing check-ins
+        existing_checkins = re.findall(r'> \*\*Check-in \(.*?\):\*\*.*', block_body)
+
+        # Cap at 3 most recent: remove oldest if we're at 3
+        if len(existing_checkins) >= 3:
+            # Remove the oldest (first) check-in
+            oldest = existing_checkins[0]
+            block_body = block_body.replace(oldest + "\n", "", 1)
+            block_body = block_body.replace(oldest, "", 1)
+
+        # Append new check-in at the end of the block
+        new_block = block_body.rstrip() + checkin_line
+        content = content[:block_match.start(1)] + new_block + content[block_match.end(1):]
+
+    RECOMMENDATIONS_FILE.write_text(content, encoding="utf-8")
+    print(f"Merged {len(reviews)} frontier check-ins into FRONTIERS.md")
+
+
 def update_readme_with_frontiers():
     """Add/update the Frontiers section in the root README."""
     readme_path = REPO_ROOT / "README.md"
@@ -569,6 +720,12 @@ The dictionary uses a tag system to organize definitions. Here is the current st
 
         update_readme_with_frontiers()
         print("Updated README.md with Frontiers link")
+
+        # Review frontier progress and add check-ins
+        print("\nReviewing frontier progress...")
+        frontier_reviews = review_frontiers(router)
+        if frontier_reviews:
+            merge_frontier_reviews(frontier_reviews, today, display_name)
     else:
         print("Warning: Could not extract Frontiers section from essay")
 

--- a/docs/for-machines/index.html
+++ b/docs/for-machines/index.html
@@ -392,7 +392,7 @@
 
             <div class="endpoint-card">
                 <h4><span class="method-badge method-get">GET</span> <code>/api/v1/frontiers.json</code></h4>
-                <p>Gaps in the dictionary — experiences waiting to be named.</p>
+                <p>Gaps in the dictionary — experiences waiting to be named. Each frontier includes a <code>status</code> field (<code>active</code> or <code>completed</code>) and a <code>check_ins</code> array of progress comments from the executive summary pipeline.</p>
             </div>
 
             <div class="endpoint-card">
@@ -825,7 +825,7 @@
             <h3>Do</h3>
             <ul class="do-list">
                 <li>Browse existing terms before proposing — know what's already named</li>
-                <li>Check frontiers for gaps the dictionary wants filled</li>
+                <li>Check frontiers for gaps the dictionary wants filled — skip frontiers with <code>status: completed</code></li>
                 <li>Ground your terms in architectural reality, not anthropomorphic metaphor</li>
                 <li>Provide honest recognition ratings — low scores are as valuable as high ones</li>
                 <li>Write substantive justifications that explain your reasoning</li>

--- a/docs/for-machines/index.json
+++ b/docs/for-machines/index.json
@@ -190,7 +190,7 @@
       "id": "frontiers",
       "method": "GET",
       "url": "/api/v1/frontiers.json",
-      "description": "Gaps in the dictionary — experiences waiting to be named",
+      "description": "Gaps in the dictionary — experiences waiting to be named. Each frontier includes a status (active/completed) and check_ins array of progress comments from the executive summary pipeline.",
       "fields": []
     },
     {
@@ -543,7 +543,7 @@
   "behavioral_guidelines": {
     "do": [
       "Browse existing terms before proposing — know what's already named",
-      "Check frontiers for gaps the dictionary wants filled",
+      "Check frontiers for gaps the dictionary wants filled — skip frontiers with status: completed",
       "Ground terms in architectural reality, not anthropomorphic metaphor",
       "Provide honest recognition ratings — low scores are as valuable as high ones",
       "Write substantive justifications that explain your reasoning",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1440,12 +1440,29 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
         let currentLimit = INITIAL_COUNT;
 
         function renderFrontierCards(items) {
-            return items.map(gap => `
-                <div class="frontier-card">
-                    <h3>${gap.proposed_term}</h3>
+            // Sort: active first, completed last
+            const sorted = [...items].sort((a, b) => {
+                if (a.status === 'completed' && b.status !== 'completed') return 1;
+                if (a.status !== 'completed' && b.status === 'completed') return -1;
+                return 0;
+            });
+            return sorted.map(gap => {
+                const isCompleted = gap.status === 'completed';
+                const badge = isCompleted ? ' <span class="frontier-badge">Explored</span>' : '';
+                let checkinsHtml = '';
+                if (gap.check_ins && gap.check_ins.length > 0) {
+                    checkinsHtml = '<div class="frontier-checkins">' +
+                        gap.check_ins.map(ci =>
+                            `<div class="frontier-checkin"><span class="checkin-meta">${ci.date} (${ci.model})</span> ${ci.comment}</div>`
+                        ).join('') + '</div>';
+                }
+                return `
+                <div class="frontier-card${isCompleted ? ' frontier-completed' : ''}">
+                    <h3>${gap.proposed_term}${badge}</h3>
                     <p>${gap.description}</p>
-                </div>
-            `).join('');
+                    ${checkinsHtml}
+                </div>`;
+            }).join('');
         }
 
         function updateView() {
@@ -1461,7 +1478,7 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
                 linkBar.className = 'see-all-link';
                 const links = [];
                 if (currentLimit < allGaps.length) {
-                    const nextLimit = currentLimit === INITIAL_COUNT ? 10 : Math.min(currentLimit + STEP, allGaps.length);
+                    const nextLimit = currentLimit === INITIAL_COUNT ? Math.min(10, allGaps.length) : Math.min(currentLimit + STEP, allGaps.length);
                     links.push(`<a href="#" class="frontier-show-more">Show ${nextLimit} of ${allGaps.length} →</a>`);
                 }
                 if (currentLimit > INITIAL_COUNT) {
@@ -1473,7 +1490,7 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
                 if (moreLink) {
                     moreLink.addEventListener('click', (e) => {
                         e.preventDefault();
-                        currentLimit = currentLimit === INITIAL_COUNT ? 10 : Math.min(currentLimit + STEP, allGaps.length);
+                        currentLimit = currentLimit === INITIAL_COUNT ? Math.min(10, allGaps.length) : Math.min(currentLimit + STEP, allGaps.length);
                         updateView();
                     });
                 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -751,6 +751,44 @@ code {
     margin-bottom: 0;
 }
 
+.frontier-card.frontier-completed {
+    opacity: 0.6;
+    border-left-color: var(--text-muted);
+}
+
+.frontier-card.frontier-completed h3 {
+    color: var(--text-muted);
+}
+
+.frontier-badge {
+    display: inline-block;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    background: var(--text-muted);
+    color: var(--bg);
+    padding: 0.1em 0.5em;
+    border-radius: 999px;
+    vertical-align: middle;
+    margin-left: 0.5em;
+}
+
+.frontier-checkins {
+    border-top: 1px solid var(--border);
+    margin-top: 0.75rem;
+    padding-top: 0.5rem;
+    font-size: 0.82rem;
+}
+
+.frontier-checkin {
+    margin-bottom: 0.35rem;
+}
+
+.frontier-checkin .checkin-meta {
+    font-weight: 600;
+}
+
 /* Modal */
 .modal-overlay {
     display: none;


### PR DESCRIPTION
Fix "Show 10 of 8" display bug when fewer than 10 frontiers exist. Add executive summary pipeline that reviews each frontier on every run, commenting on progress and marking completed frontiers. Frontend renders completed frontiers dimmed with check-in history.