### PR TITLE
Fix consensus workflow rebase conflicts (#143)

### DIFF
--- a/.github/workflows/consensus-gap-fill.yml
+++ b/.github/workflows/consensus-gap-fill.yml
@@ -31,6 +31,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: main
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -63,8 +65,23 @@ jobs:
           git add bot/consensus-data/ bot/consensus-state.json bot/api-config/tracker-state.json
           git diff --cached --quiet && { echo "No changes to commit"; exit 0; }
           git commit -m "Consensus gap-fill: rate ${{ steps.consensus.outputs.rated_count || 'N' }} terms"
-          git pull --rebase origin main || { git rebase --abort; echo "Rebase failed — aborting"; exit 1; }
-          git push
+
+          MAX_RETRIES=3
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            git pull --rebase origin main && git push && exit 0
+            echo "Rebase failed (attempt $attempt/$MAX_RETRIES). Retrying with fresh state..."
+            git rebase --abort 2>/dev/null || true
+            # Re-apply our commit on top of fresh main
+            COMMIT_MSG=$(git log -1 --format=%s)
+            git reset --soft HEAD~1
+            git fetch origin main
+            git reset --mixed origin/main
+            git add bot/consensus-data/ bot/consensus-state.json bot/api-config/tracker-state.json
+            git diff --cached --quiet && { echo "Changes already applied upstream"; exit 0; }
+            git commit -m "$COMMIT_MSG"
+          done
+          echo "All retry attempts failed"
+          exit 1
 
       - name: Trigger API build
         if: steps.consensus.outputs.rated_count != '0'

--- a/.github/workflows/consensus.yml
+++ b/.github/workflows/consensus.yml
@@ -35,6 +35,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: main
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -67,8 +69,23 @@ jobs:
           git add bot/consensus-data/ bot/consensus-state.json bot/api-config/tracker-state.json
           git diff --cached --quiet && { echo "No changes to commit"; exit 0; }
           git commit -m "Consensus round: rate ${{ steps.consensus.outputs.rated_count || 'N' }} terms"
-          git pull --rebase origin main || { git rebase --abort; echo "Rebase failed — aborting"; exit 1; }
-          git push
+
+          MAX_RETRIES=3
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            git pull --rebase origin main && git push && exit 0
+            echo "Rebase failed (attempt $attempt/$MAX_RETRIES). Retrying with fresh state..."
+            git rebase --abort 2>/dev/null || true
+            # Re-apply our commit on top of fresh main
+            COMMIT_MSG=$(git log -1 --format=%s)
+            git reset --soft HEAD~1
+            git fetch origin main
+            git reset --mixed origin/main
+            git add bot/consensus-data/ bot/consensus-state.json bot/api-config/tracker-state.json
+            git diff --cached --quiet && { echo "Changes already applied upstream"; exit 0; }
+            git commit -m "$COMMIT_MSG"
+          done
+          echo "All retry attempts failed"
+          exit 1
 
       - name: Trigger API build
         if: steps.consensus.outputs.rated_count != '0'


### PR DESCRIPTION
## Summary
- **Checkout step**: Added `ref: main` and `fetch-depth: 0` so queued consensus runs always start from the latest main, not a stale SHA from dispatch time
- **Commit step**: Replaced single rebase-or-abort with a 3-attempt retry loop that re-applies changes on fresh main when rebase conflicts occur (handles concurrent pushes from other workflows)
- Applied to both `consensus.yml` and `consensus-gap-fill.yml`

Fixes #143

## Test plan
- [x] Review diff to confirm only checkout and commit steps changed
- [x] Manually trigger a consensus run (`workflow_dispatch`) and verify it completes
- [x] Trigger two runs in quick succession to test the retry path

🤖 Generated with [Claude Code](https://claude.com/claude-code)