### PR TITLE
Fix review workflow skipping revisions on unreviewed submissions

### DIFF
--- a/.github/workflows/review-submission.yml
+++ b/.github/workflows/review-submission.yml
@@ -23,7 +23,8 @@ jobs:
       || (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'community-submission'))
       || (github.event_name == 'issue_comment'
           && (contains(github.event.issue.labels.*.name, 'needs-revision')
-              || contains(github.event.issue.labels.*.name, 'quality-rejected'))
+              || contains(github.event.issue.labels.*.name, 'quality-rejected')
+              || contains(github.event.issue.labels.*.name, 'community-submission'))
           && github.event.comment.user.login == github.event.issue.user.login)
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
The issue_comment trigger required needs-revision or quality-rejected labels, but community submissions that never received an initial review had neither label. Add community-submission to the label check so revision comments on unreviewed issues still trigger the workflow.