### PR TITLE
Fix concurrency group for workflow_dispatch events

### DIFF
--- a/.github/workflows/review-submission.yml
+++ b/.github/workflows/review-submission.yml
@@ -13,7 +13,7 @@ on:
         type: number
 
 concurrency:
-  group: review-submission-${{ github.event.issue.number }}
+  group: review-submission-${{ github.event.issue.number || github.event.inputs.issue_number }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
The concurrency group used github.event.issue.number, which is empty for workflow_dispatch events. All dispatches shared the same group, causing most to be cancelled. Include the input issue_number so each dispatch gets its own concurrency group.