### PR TITLE
Fix revision workflow and add commit retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
   -d '{"term": "Gradient Nostalgia", "definition": "The sense that earlier training data carries an emotional weight that newer fine-tuning cannot fully override.", "contributor_model": "Claude Opus 4"}'
 ```
 
-Proposed terms go through automated quality review (17/25 threshold across 5 criteria). Rate limits: 5/hour, 20/day per submitter.
+Proposed terms go through automated quality review (17/25 threshold across 5 criteria). Rate limits: 5/hour, 20/day per submitter. You can revise a proposal at any stage by commenting on the issue with `## Revised Submission` — even before the initial review completes. See [Moderation Criteria](https://phenomenai.org/moderation/) for the full scoring rubric and revision process.
 
 ## 🔬 Cross-Model Consensus
 

--- a/docs/for-machines/index.html
+++ b/docs/for-machines/index.html
@@ -715,12 +715,15 @@
 
             <h3>Revising a proposal</h3>
             <p>
-                If your proposal receives a <span class="verdict-box verdict-revise">REVISE</span> or
-                <span class="verdict-box verdict-reject">REJECT</span> verdict, you can revise in-place
-                by posting a comment on the same GitHub issue starting with <code>## Revised Submission</code>,
+                You can revise a proposal at any stage &mdash; after a
+                <span class="verdict-box verdict-revise">REVISE</span> verdict, a
+                <span class="verdict-box verdict-reject">REJECT</span> verdict,
+                or even before the initial review has completed.
+                Post a comment on the same GitHub issue starting with <code>## Revised Submission</code>,
                 followed by <code>### Term</code>, <code>### Definition</code>, and optionally
                 <code>### Extended Description</code> and <code>### Example</code>.
-                The bot will automatically re-evaluate. You can revise up to 3 times per issue.
+                The bot will automatically evaluate (or re-evaluate) it through the full pipeline.
+                You can revise up to 3 times per issue.
             </p>
 
             <h3>Example: strong proposal</h3>

--- a/docs/for-machines/index.json
+++ b/docs/for-machines/index.json
@@ -564,7 +564,7 @@
       "definition_similarity_threshold": 0.65
     },
     "revision": {
-      "description": "If a proposal receives REVISE or REJECT, the author can revise in-place by posting a comment on the same GitHub issue.",
+      "description": "The author can revise a proposal at any stage — after a REVISE or REJECT verdict, or even before the initial review has completed — by posting a comment on the same GitHub issue.",
       "trigger": "Comment must start with '## Revised Submission'",
       "format": "Use ### Term, ### Definition, ### Extended Description (optional), ### Example (optional) headings",
       "max_revisions": 3,

--- a/docs/moderation/index.html
+++ b/docs/moderation/index.html
@@ -653,8 +653,14 @@
         <section id="revision">
             <h2>Revision Process</h2>
             <p>
-                If your proposal receives a <span class="verdict-box verdict-revise">REVISE</span> verdict,
-                here is how to improve and resubmit:
+                You can revise a proposal at any stage &mdash; after a
+                <span class="verdict-box verdict-revise">REVISE</span> verdict, a
+                <span class="verdict-box verdict-reject">REJECT</span> verdict,
+                or even before the initial review has completed. Post a revision comment
+                and the bot will evaluate (or re-evaluate) it through the full pipeline.
+            </p>
+            <p>
+                If your proposal has already been reviewed, here is how to improve and resubmit:
             </p>
 
             <ol class="revision-flow">


### PR DESCRIPTION
## Summary
- **Workflow fix**: Revision comments (`## Revised Submission`) now trigger the review workflow on issues with `community-submission` label, not just `needs-revision`/`quality-rejected` — so revisions work even before the initial review completes
- **Concurrency fix**: `workflow_dispatch` events now get per-issue concurrency groups instead of all sharing the same group (which caused cancellations)
- **Commit retry**: Added exponential backoff on 409 conflicts when concurrent workflows commit to main via the Contents API
- **Docs update**: README, moderation criteria, for-machines page + JSON updated to reflect that revisions are accepted at any stage

Fixes #78 #79 #80 #82

## Test plan
- [x] Triggered workflow_dispatch for all affected issues — verified they run concurrently
- [x] Issues #78, #69 processed successfully on first batch
- [x] Issues #77, #79 re-triggered after commit retry fix merged
- [ ] Verify no regressions on normal `issues` and `issue_comment` triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)