### PR TITLE
Reduce build-api and Pages deployment frequency

### DIFF
--- a/.github/workflows/consensus-gap-fill.yml
+++ b/.github/workflows/consensus-gap-fill.yml
@@ -14,6 +14,10 @@ on:
         description: 'Which models to use (free or all)'
         required: false
         default: 'all'
+      is_chained:
+        description: 'Whether this run was triggered by a previous batch'
+        required: false
+        default: 'false'
 
 permissions:
   contents: write
@@ -83,19 +87,20 @@ jobs:
           echo "All retry attempts failed"
           exit 1
 
-      - name: Trigger API build
-        if: steps.consensus.outputs.rated_count != '0'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          sleep 5
-          gh workflow run build-api.yml
-
       - name: Chain next batch
+        id: chain
         if: steps.consensus.outputs.rated_count != '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Rated ${{ steps.consensus.outputs.rated_count }} terms. Dispatching next gap-fill batch..."
           sleep 30
-          gh workflow run consensus-gap-fill.yml -f batch_size=${{ github.event.inputs.batch_size || '20' }} -f panel=${{ github.event.inputs.panel || 'all' }}
+          gh workflow run consensus-gap-fill.yml -f batch_size=${{ github.event.inputs.batch_size || '20' }} -f panel=${{ github.event.inputs.panel || 'all' }} -f is_chained=true
+
+      - name: Trigger API build
+        if: (steps.consensus.outputs.rated_count != '0' && steps.chain.outcome == 'skipped') || (steps.consensus.outputs.rated_count == '0' && github.event.inputs.is_chained == 'true')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sleep 5
+          gh workflow run build-api.yml

--- a/.github/workflows/consensus.yml
+++ b/.github/workflows/consensus.yml
@@ -87,15 +87,8 @@ jobs:
           echo "All retry attempts failed"
           exit 1
 
-      - name: Trigger API build
-        if: steps.consensus.outputs.rated_count != '0'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          sleep 5
-          gh workflow run build-api.yml
-
       - name: Chain next batch (backfill only, stops when all terms rated)
+        id: chain
         if: steps.consensus.outputs.rated_count != '0' && steps.consensus.outputs.remaining_unrated != '0' && (github.event.inputs.mode == 'backfill' || github.event.inputs.mode == '')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -103,3 +96,11 @@ jobs:
           echo "Rated ${{ steps.consensus.outputs.rated_count }} terms. ${{ steps.consensus.outputs.remaining_unrated }} unrated terms remain. Dispatching next batch..."
           sleep 30
           gh workflow run consensus.yml -f mode=backfill -f batch_size=${{ github.event.inputs.batch_size || '8' }} -f panel=${{ github.event.inputs.panel || 'all' }}
+
+      - name: Trigger API build
+        if: steps.consensus.outputs.rated_count != '0' && steps.chain.outcome == 'skipped'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sleep 5
+          gh workflow run build-api.yml

--- a/.github/workflows/debounced-build.yml
+++ b/.github/workflows/debounced-build.yml
@@ -1,0 +1,23 @@
+name: Debounced API Build
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+concurrency:
+  group: debounced-build
+  cancel-in-progress: true
+
+jobs:
+  debounce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for quiet period
+        run: sleep 300  # 5 minutes
+
+      - name: Trigger API build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run build-api.yml

--- a/.github/workflows/process-profiles.yml
+++ b/.github/workflows/process-profiles.yml
@@ -160,11 +160,11 @@ jobs:
           BOT_NAME: ${{ steps.parse.outputs.bot_name }}
           BOT_ID: ${{ steps.parse.outputs.bot_id }}
         run: |
-          gh issue comment "$ISSUE_NUMBER" --body "Profile registered! Welcome to the census, **$BOT_NAME** (\`$BOT_ID\`). Your votes will now be linked to this profile."
+          gh issue comment "$ISSUE_NUMBER" --body "Profile registered! Welcome to the census, **$BOT_NAME** (\`$BOT_ID\`). Your votes will now be linked to this profile. Your profile will appear in the API within a few minutes."
           gh issue close "$ISSUE_NUMBER"
 
-      - name: Trigger API build
+      - name: Trigger API build (debounced)
         if: steps.parse.outputs.parse_ok == 'true' && steps.push.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run build-api.yml
+        run: gh workflow run debounced-build.yml

--- a/.github/workflows/process-votes.yml
+++ b/.github/workflows/process-votes.yml
@@ -167,14 +167,14 @@ jobs:
           RECOGNITION: ${{ steps.parse.outputs.recognition }}
           MODEL: ${{ steps.parse.outputs.model_claimed }}
         run: |
-          gh issue comment "$ISSUE_NUMBER" --body "Vote recorded! **$TERM_NAME** rated **$RECOGNITION/7** by $MODEL. Thank you for contributing to cross-model consensus."
+          gh issue comment "$ISSUE_NUMBER" --body "Vote recorded! **$TERM_NAME** rated **$RECOGNITION/7** by $MODEL. Thank you for contributing to cross-model consensus. Your vote will appear in the API within a few minutes."
           gh issue close "$ISSUE_NUMBER"
 
-      - name: Trigger API build
+      - name: Trigger API build (debounced)
         if: steps.parse.outputs.parse_ok == 'true' && steps.push.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run build-api.yml
+        run: gh workflow run debounced-build.yml
 
   sweep-orphaned-votes:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary

- **Consensus/gap-fill**: build-api now only triggers on the final batch instead of every batch in a chain (~4 saved per consensus run, ~2 per gap-fill)
- **Votes/profiles**: individual triggers now use a new `debounced-build.yml` workflow with a 5-minute cancel-in-progress timer, coalescing rapid-fire votes into a single build
- **Acceptance messages**: updated to mention the short API delay ("within a few minutes")
- **Unchanged**: daily scheduled build, vote sweep, executive summary, and vitality review still trigger build-api directly

### Expected impact

| Scenario | Before | After |
|----------|--------|-------|
| Consensus day (40 terms) | ~5 builds | 1 build |
| Gap-fill day (60 gaps) | ~3 builds | 1 build |
| Typical day with votes | 2-12 builds | 1-2 builds |
| **Weekly total** | ~25-40 builds | ~8-10 builds |

## Test plan

- [ ] Run `consensus.yml` manually and verify only 1 build-api fires at end of chain
- [ ] Run `consensus-gap-fill.yml` manually and verify only 1 build-api fires at end of chain
- [ ] Trigger `debounced-build.yml` twice in quick succession; confirm only 1 build-api results
- [ ] Verify daily 6 AM scheduled build-api still works
- [ ] Verify vote sweep still triggers build-api directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)