### PR TITLE
Fix debounced-consensus and remove duplicate triggers

### DIFF
--- a/.github/workflows/debounced-consensus.yml
+++ b/.github/workflows/debounced-consensus.yml
@@ -14,6 +14,9 @@ jobs:
   debounce:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Wait for quiet period
         run: sleep 480  # 8 minutes
 

--- a/bot/review_submission.py
+++ b/bot/review_submission.py
@@ -38,8 +38,6 @@ REVISION_MARKER = "## Revised Submission"
 
 REPO_ROOT = Path(__file__).parent.parent
 DEFINITIONS_DIR = REPO_ROOT / "definitions"
-CONSENSUS_DATA_DIR = Path(__file__).parent / "consensus-data"
-CONSENSUS_BATCH_SIZE = 8
 API_CONFIG_DIR = Path(__file__).parent / "api-config"
 
 QUALITY_THRESHOLD = 17  # out of 25
@@ -776,19 +774,11 @@ def main():
         remove_labels(["needs-manual-review", "needs-revision", "needs-formatting", "revision-pending"])
         add_labels(["accepted"])
         close_issue()
-        # Trigger consensus: immediately if a full batch is ready,
-        # otherwise debounce so stragglers get picked up after a quiet period.
-        rated = {f.stem for f in CONSENSUS_DATA_DIR.glob("*.json")} if CONSENSUS_DATA_DIR.exists() else set()
-        all_terms = {f.stem for f in DEFINITIONS_DIR.glob("*.md") if f.name != "README.md"}
-        unrated = len(all_terms - rated)
-        if unrated >= CONSENSUS_BATCH_SIZE:
-            trigger_workflow("consensus.yml", inputs={"mode": "backfill", "batch_size": str(CONSENSUS_BATCH_SIZE), "panel": "all"})
-            print(f"  ✓ Committed: definitions/{slug}.md")
-            print(f"  ✓ Triggered consensus (batch — {unrated} unrated terms)")
-        else:
-            trigger_workflow("debounced-consensus.yml")
-            print(f"  ✓ Committed: definitions/{slug}.md")
-            print(f"  ✓ Triggered debounced-consensus ({unrated} unrated, waiting for batch)")
+        # Always debounce — cancel-in-progress deduplicates concurrent
+        # acceptances, then consensus backfill picks up all unrated terms.
+        trigger_workflow("debounced-consensus.yml")
+        print(f"  ✓ Committed: definitions/{slug}.md")
+        print(f"  ✓ Triggered debounced-consensus")
     except Exception as e:
         comment_on_issue(
             f"{score_table}\n\n---\n\n"


### PR DESCRIPTION
## Summary

Fixes two issues from the previous PR's deployment:

- **Debounced consensus failed** — `gh workflow run` needs a git repo context to resolve the target repository. Added a checkout step so `gh` can read the remote URL.
- **Multiple consensus runs dispatched simultaneously** — Parallel review-submission jobs each independently hit the `unrated >= 8` threshold and dispatched `consensus.yml` directly, causing 3 cancelled runs. Removed the direct trigger path; all acceptances now go through `debounced-consensus.yml`, whose `cancel-in-progress: true` naturally deduplicates.

## Test plan

- [ ] Accept a term — verify debounced-consensus starts and completes successfully
- [ ] Accept multiple terms rapidly — verify only one debounced-consensus survives (others cancelled)
- [ ] Verify consensus runs after the 8-minute quiet period, then triggers build-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)