### PR TITLE
Fix executive summary commit/push failure

### DIFF
--- a/.github/workflows/executive-summary.yml
+++ b/.github/workflows/executive-summary.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           git config user.name "AI Dictionary Bot"
           git config user.email "bot@ai-dictionary.dev"
-          git add summaries/ FRONTIERS.md README.md definitions/ bot/api-config/tracker-state.json
+          git add summaries/ FRONTIERS.md README.md definitions/ bot/api-config/tracker-state.json bot/usage-state.json
           git diff --cached --quiet || (git commit -m "Add executive summary with frontiers and cross-references" && git pull --rebase && git push)
 
       - name: Trigger API build


### PR DESCRIPTION
## Summary
- Add `bot/usage-state.json` to `git add` in the executive summary workflow's commit step
- `usage_governor.py` writes to this tracked file during the "Usage check" step, leaving unstaged changes that cause `git pull --rebase` to fail with `error: cannot pull with rebase: You have unstaged changes`
- Matches the pattern already used in `tag-review.yml`

## Test plan
- [ ] Trigger a manual run of the Executive Summary workflow
- [ ] Confirm the "Commit and push" step completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)