### PR TITLE
Paginate dictionary: show 10 terms at a time

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -885,7 +885,11 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
         URL.revokeObjectURL(url);
     }
 
-    function renderTerms() {
+    var termsVisible = 10;
+    var TERMS_PAGE_SIZE = 10;
+
+    function renderTerms(resetPage) {
+        if (resetPage !== false) termsVisible = TERMS_PAGE_SIZE;
         const filtered = getFilteredTerms();
         const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 
@@ -898,7 +902,10 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
             return;
         }
 
-        container.innerHTML = filtered.map(term => `
+        const visible = filtered.slice(0, termsVisible);
+        const hasMore = filtered.length > termsVisible;
+
+        container.innerHTML = visible.map(term => `
             <div class="term-card" data-slug="${term.slug}">
                 <div class="term-header">
                     <h3>${term.name}</h3>
@@ -913,7 +920,7 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
                     ${term.tags.map(t => `<span class="tag">${t}</span>`).join('')}
                 </div>
             </div>
-        `).join('');
+        `).join('') + (hasMore ? `<button class="show-more-btn" id="show-more-terms">Show more (${filtered.length - termsVisible} remaining)</button>` : '');
 
         // Click to expand
         container.querySelectorAll('.term-card').forEach(card => {
@@ -923,6 +930,15 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
                 if (term) showModal(term);
             });
         });
+
+        // Show more button
+        const showMoreBtn = document.getElementById('show-more-terms');
+        if (showMoreBtn) {
+            showMoreBtn.addEventListener('click', () => {
+                termsVisible += TERMS_PAGE_SIZE;
+                renderTerms(false);
+            });
+        }
     }
 
     function showModal(term) {

--- a/docs/style.css
+++ b/docs/style.css
@@ -1042,6 +1042,23 @@ code {
 
 .error { color: #dc2626; }
 .no-results { color: var(--text-muted); text-align: center; padding: 2rem; }
+.show-more-btn {
+    display: block;
+    width: 100%;
+    padding: 0.75rem;
+    margin-top: 0.5rem;
+    background: var(--bg-card);
+    color: var(--text-muted);
+    border: 1px dashed var(--border);
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 0.95rem;
+    transition: background 0.2s, color 0.2s;
+}
+.show-more-btn:hover {
+    background: var(--accent);
+    color: var(--bg);
+}
 
 /* Footer */
 footer {


### PR DESCRIPTION
## Summary
- Dictionary now shows 10 terms at a time instead of all at once
- "Show more" button loads the next 10 terms, showing how many remain
- Search or tag filter resets pagination back to 10

## Test plan
- [ ] Verify only 10 terms display on initial load
- [ ] Click "Show more" and confirm 10 more terms appear
- [ ] Search/filter and confirm pagination resets
- [ ] Verify button styling in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)