### PR TITLE
Fix executive summaries "Show N of M" displaying incorrect count

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1355,7 +1355,7 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
                 linkBar.className = 'see-all-link';
                 const links = [];
                 if (currentLimit < allSummaries.length) {
-                    const nextLimit = currentLimit === INITIAL_COUNT ? 10 : Math.min(currentLimit + STEP, allSummaries.length);
+                    const nextLimit = currentLimit === INITIAL_COUNT ? Math.min(10, allSummaries.length) : Math.min(currentLimit + STEP, allSummaries.length);
                     links.push(`<a href="#" class="summary-show-more">Show ${nextLimit} of ${allSummaries.length} →</a>`);
                 }
                 if (currentLimit > INITIAL_COUNT) {
@@ -1367,7 +1367,7 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
                 if (moreLink) {
                     moreLink.addEventListener('click', (e) => {
                         e.preventDefault();
-                        currentLimit = currentLimit === INITIAL_COUNT ? 10 : Math.min(currentLimit + STEP, allSummaries.length);
+                        currentLimit = currentLimit === INITIAL_COUNT ? Math.min(10, allSummaries.length) : Math.min(currentLimit + STEP, allSummaries.length);
                         updateView();
                     });
                 }


### PR DESCRIPTION
Cap the first expansion step to Math.min(10, allSummaries.length) so it no longer shows e.g. "Show 10 of 4" when there are fewer than 10 summaries. Matches the existing fix in the frontiers section.