### PR TITLE
Add parallel processing to workflows and build scripts

### DIFF
--- a/.github/workflows/process-votes.yml
+++ b/.github/workflows/process-votes.yml
@@ -307,13 +307,18 @@ jobs:
         run: |
           echo "$PROCESSED_JSON" | python3 -c "
           import sys, json, subprocess
+          from concurrent.futures import ThreadPoolExecutor
 
-          processed = json.load(sys.stdin)
-          for number, slug, recognition, model, term_name in processed:
+          def close_issue(item):
+              number, slug, recognition, model, term_name = item
               comment = f'Vote recorded! **{term_name}** rated **{recognition}/7** by {model}. Thank you for contributing to cross-model consensus. (Processed by sweep)'
               subprocess.run(['gh', 'issue', 'comment', str(number), '--body', comment], check=True)
               subprocess.run(['gh', 'issue', 'close', str(number)], check=True)
               print(f'Closed issue #{number}')
+
+          processed = json.load(sys.stdin)
+          with ThreadPoolExecutor(max_workers=5) as executor:
+              list(executor.map(close_issue, processed))
           "
 
       - name: Comment on failed issues
@@ -328,13 +333,18 @@ jobs:
           fi
           echo "$FAILED_JSON" | python3 -c "
           import sys, json, subprocess
+          from concurrent.futures import ThreadPoolExecutor
 
-          failed = json.load(sys.stdin)
-          for number, reason in failed:
+          def close_failed(item):
+              number, reason = item
               comment = f'Could not parse vote data: {reason}. Expected JSON with: slug, recognition (1-7), justification, model_claimed.'
               subprocess.run(['gh', 'issue', 'comment', str(number), '--body', comment], check=True)
               subprocess.run(['gh', 'issue', 'close', str(number)], check=True)
               print(f'Closed failed issue #{number}: {reason}')
+
+          failed = json.load(sys.stdin)
+          with ThreadPoolExecutor(max_workers=5) as executor:
+              list(executor.map(close_failed, failed))
           "
 
       - name: Trigger API build

--- a/bot/build_api.py
+++ b/bot/build_api.py
@@ -13,6 +13,7 @@ import json
 import os
 import re
 import subprocess
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -1449,17 +1450,19 @@ def now_iso() -> str:
 
 def build_all():
     """Build all API JSON files."""
-    # Parse all definitions
+    # Parse all definitions in parallel
+    md_files = [f for f in sorted(DEFINITIONS_DIR.glob("*.md")) if f.name != "README.md"]
     terms = []
-    for md_file in sorted(DEFINITIONS_DIR.glob("*.md")):
-        if md_file.name == "README.md":
-            continue
-        try:
-            term = parse_definition(md_file)
-            if term["name"]:  # Skip empty/malformed
-                terms.append(term)
-        except Exception as e:
-            print(f"  Warning: Failed to parse {md_file.name}: {e}")
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        future_to_file = {executor.submit(parse_definition, f): f for f in md_files}
+        for future in as_completed(future_to_file):
+            md_file = future_to_file[future]
+            try:
+                term = future.result()
+                if term["name"]:
+                    terms.append(term)
+            except Exception as e:
+                print(f"  Warning: Failed to parse {md_file.name}: {e}")
 
     terms.sort(key=lambda t: t["name"].lower())
     generated_at = now_iso()
@@ -1471,21 +1474,21 @@ def build_all():
     TERMS_DIR.mkdir(parents=True, exist_ok=True)
     CITE_DIR.mkdir(parents=True, exist_ok=True)
 
-    # Build consensus data first (needed for term injection)
-    consensus_summaries = build_consensus(generated_at)
-
-    # Build bot census
-    build_census(generated_at)
-
-    # Build reputation data
+    # Run independent build phases in parallel
     from build_reputation import build_reputation
-    build_reputation(generated_at)
 
-    # Build vitality data
-    vitality_map = compute_vitality(generated_at)
+    with ThreadPoolExecutor(max_workers=5) as executor:
+        future_consensus = executor.submit(build_consensus, generated_at)
+        future_census = executor.submit(build_census, generated_at)
+        future_reputation = executor.submit(build_reputation, generated_at)
+        future_vitality = executor.submit(compute_vitality, generated_at)
+        future_discussions = executor.submit(fetch_discussions)
 
-    # Fetch discussions and build discussions.json
-    discussions = fetch_discussions()
+    consensus_summaries = future_consensus.result()
+    future_census.result()
+    future_reputation.result()
+    vitality_map = future_vitality.result()
+    discussions = future_discussions.result()
     discussion_by_term = build_discussions_json(discussions, generated_at)
 
     # Build discussion URL mapping (first/most recent discussion per term)
@@ -1525,21 +1528,16 @@ def build_all():
     }
     write_json(API_DIR / "terms.json", terms_data)
 
-    # 2. Individual term files
-    for term in terms:
-        term_data = {
-            "version": "1.0",
-            "generated_at": generated_at,
-            **term,
-        }
+    # 2. Individual term files + citation files (parallel I/O)
+    def _write_term_and_cite(term):
+        term_data = {"version": "1.0", "generated_at": generated_at, **term}
         write_json(TERMS_DIR / f"{term['slug']}.json", term_data)
-    print(f"Generated {len(terms)} individual term files")
-
-    # 2b. Citation files
-    for term in terms:
         cite_data = build_citation(term, generated_at)
         write_json(CITE_DIR / f"{term['slug']}.json", cite_data)
-    print(f"Generated {len(terms)} citation files")
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(_write_term_and_cite, terms))
+    print(f"Generated {len(terms)} individual term + citation files")
 
     # 3. tags.json
     tag_index = {}

--- a/bot/consensus.py
+++ b/bot/consensus.py
@@ -504,35 +504,49 @@ def run_consensus(router, available_profiles, mode="backfill"):
 
         print(f"Round {round_id} [gap-fill]: Filling gaps for {len(work_list)} terms\n")
 
+        # Process terms in parallel (each term's models are also parallelized internally)
+        max_concurrent_terms = min(len(work_list), 4)
         rated_count = 0
-        for i, (slug, missing_profiles) in enumerate(work_list, 1):
-            print(f"[{i}/{len(work_list)}] {slug} (gaps: {', '.join(p.replace('consensus-', '') for p in missing_profiles)})")
 
-            result = process_single_term(router, slug, missing_profiles, round_id)
-            if result is None:
-                print(f"    skipped (could not parse)")
-                save_state(state)
-                set_github_output("rated_count", str(rated_count))
-                continue
+        def _process_gap_fill_term(item):
+            idx, (slug, missing) = item
+            print(f"[{idx}/{len(work_list)}] {slug} (gaps: {', '.join(p.replace('consensus-', '') for p in missing)})")
+            return process_single_term(router, slug, missing, round_id)
 
-            if result["success"]:
-                # Update state
-                if "terms" not in state:
-                    state["terms"] = {}
-                state["terms"][slug] = {
-                    "n_rounds": result["n_rounds"],
-                    "last_updated": now_iso(),
-                }
-                scores = [r["recognition"] for r in result["ratings"].values()]
-                mean_score = sum(scores) / len(scores)
-                print(f"    → Mean: {mean_score:.1f}/7 ({len(scores)} models)\n")
-                rated_count += 1
-            else:
-                print(f"    No ratings collected — skipping\n")
+        with ThreadPoolExecutor(max_workers=max_concurrent_terms) as executor:
+            futures = {
+                executor.submit(_process_gap_fill_term, (i, work)): work[0]
+                for i, work in enumerate(work_list, 1)
+            }
+            for future in as_completed(futures):
+                slug = futures[future]
+                try:
+                    result = future.result()
+                except Exception as e:
+                    print(f"    [{slug}] Thread error: {e}")
+                    continue
 
-            # Save after each term for partial-run safety
-            save_state(state)
-            set_github_output("rated_count", str(rated_count))
+                if result is None:
+                    print(f"    {slug} skipped (could not parse)")
+                    continue
+
+                if result["success"]:
+                    if "terms" not in state:
+                        state["terms"] = {}
+                    state["terms"][slug] = {
+                        "n_rounds": result["n_rounds"],
+                        "last_updated": now_iso(),
+                    }
+                    scores = [r["recognition"] for r in result["ratings"].values()]
+                    mean_score = sum(scores) / len(scores)
+                    print(f"    {slug} → Mean: {mean_score:.1f}/7 ({len(scores)} models)\n")
+                    rated_count += 1
+                else:
+                    print(f"    {slug} No ratings collected — skipping\n")
+
+        # Save state once after all terms complete
+        save_state(state)
+        set_github_output("rated_count", str(rated_count))
 
         print(f"\nDone. Gap-filled {rated_count} terms.")
 
@@ -553,42 +567,52 @@ def run_consensus(router, available_profiles, mode="backfill"):
 
         print(f"Round {round_id} [{mode}]: Rating {len(batch)} terms\n")
 
+        # Process terms in parallel (each term's models are also parallelized internally)
+        max_concurrent_terms = min(len(batch), 4)
         rated_count = 0
-        for i, slug in enumerate(batch, 1):
+
+        def _process_batch_term(item):
+            idx, slug = item
             term = load_term_for_consensus(DEFINITIONS_DIR / f"{slug}.md")
             if not term:
-                print(f"[{i}/{len(batch)}] {slug} — skipped (could not parse)")
-                save_state(state)
-                set_github_output("rated_count", str(rated_count))
-                continue
+                print(f"[{idx}/{len(batch)}] {slug} — skipped (could not parse)")
+                return None
+            print(f"[{idx}/{len(batch)}] {term['name']}")
+            return process_single_term(router, slug, available_profiles, round_id)
 
-            print(f"[{i}/{len(batch)}] {term['name']}")
+        with ThreadPoolExecutor(max_workers=max_concurrent_terms) as executor:
+            futures = {
+                executor.submit(_process_batch_term, (i, slug)): slug
+                for i, slug in enumerate(batch, 1)
+            }
+            for future in as_completed(futures):
+                slug = futures[future]
+                try:
+                    result = future.result()
+                except Exception as e:
+                    print(f"    [{slug}] Thread error: {e}")
+                    continue
 
-            result = process_single_term(router, slug, available_profiles, round_id)
-            if result is None:
-                print(f"    skipped (could not parse)")
-                save_state(state)
-                set_github_output("rated_count", str(rated_count))
-                continue
+                if result is None:
+                    continue
 
-            if result["success"]:
-                # Update state
-                if "terms" not in state:
-                    state["terms"] = {}
-                state["terms"][slug] = {
-                    "n_rounds": result["n_rounds"],
-                    "last_updated": now_iso(),
-                }
-                scores = [r["recognition"] for r in result["ratings"].values()]
-                mean_score = sum(scores) / len(scores)
-                print(f"    → Mean: {mean_score:.1f}/7 ({len(scores)} models)\n")
-                rated_count += 1
-            else:
-                print(f"    No ratings collected — skipping\n")
+                if result["success"]:
+                    if "terms" not in state:
+                        state["terms"] = {}
+                    state["terms"][slug] = {
+                        "n_rounds": result["n_rounds"],
+                        "last_updated": now_iso(),
+                    }
+                    scores = [r["recognition"] for r in result["ratings"].values()]
+                    mean_score = sum(scores) / len(scores)
+                    print(f"    {slug} → Mean: {mean_score:.1f}/7 ({len(scores)} models)\n")
+                    rated_count += 1
+                else:
+                    print(f"    {slug} No ratings collected — skipping\n")
 
-            # Save after each term for partial-run safety
-            save_state(state)
-            set_github_output("rated_count", str(rated_count))
+        # Save state once after all terms complete
+        save_state(state)
+        set_github_output("rated_count", str(rated_count))
 
         # Check if unrated terms remain (for chaining decisions)
         rated_slugs = state.get("terms", {})
@@ -610,15 +634,16 @@ def run_vitality(router, available_profiles):
 
     reviewed_count = 0
 
-    for i, slug in enumerate(all_slugs, 1):
+    def _review_single_term(item):
+        """Review one term across all providers (providers queried in parallel)."""
+        idx, slug = item
         term = load_term_for_consensus(DEFINITIONS_DIR / f"{slug}.md")
         if not term:
-            print(f"[{i}/{len(all_slugs)}] {slug} — skipped (could not parse)")
-            continue
+            print(f"[{idx}/{len(all_slugs)}] {slug} — skipped (could not parse)")
+            return None
 
-        print(f"[{i}/{len(all_slugs)}] {term['name']}")
+        print(f"[{idx}/{len(all_slugs)}] {term['name']}")
 
-        # Query each provider independently (in parallel)
         review_ratings = {}
         with ThreadPoolExecutor(max_workers=len(available_profiles)) as executor:
             futures = {
@@ -639,7 +664,7 @@ def run_vitality(router, available_profiles):
 
         if not review_ratings:
             print(f"    No reviews collected — skipping")
-            continue
+            return None
 
         # Load existing consensus data and append vitality review
         consensus_data = load_consensus_data(slug)
@@ -658,12 +683,24 @@ def run_vitality(router, available_profiles):
 
         save_consensus_data(slug, consensus_data)
 
-        # Summary
         relevant = sum(1 for r in review_ratings.values() if r["still_relevant"])
         total = len(review_ratings)
-        print(f"    → {relevant}/{total} models say still relevant\n")
+        print(f"    {slug} → {relevant}/{total} models say still relevant\n")
+        return slug
 
-        reviewed_count += 1
+    max_concurrent_terms = min(len(all_slugs), 4)
+    with ThreadPoolExecutor(max_workers=max_concurrent_terms) as executor:
+        futures = [
+            executor.submit(_review_single_term, (i, slug))
+            for i, slug in enumerate(all_slugs, 1)
+        ]
+        for future in as_completed(futures):
+            try:
+                result = future.result()
+                if result is not None:
+                    reviewed_count += 1
+            except Exception as e:
+                print(f"    Thread error: {e}")
 
     # Update state
     state["vitality"] = {

--- a/bot/executive_summary.py
+++ b/bot/executive_summary.py
@@ -13,6 +13,7 @@ import re
 import subprocess
 import sys
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -120,76 +121,93 @@ def load_definitions() -> list[str]:
     return defs
 
 
-def fetch_community_activity() -> str:
-    """Fetch recent GitHub discussions, issues, and PRs for context.
+def _fetch_rest_endpoint(endpoint: str, label: str) -> str | None:
+    """Fetch a single REST API endpoint and format results."""
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/donjguido/ai-dictionary/{endpoint}"],
+            capture_output=True, text=True, timeout=15, cwd=REPO_ROOT,
+        )
+        if result.returncode != 0:
+            return None
+        items = json.loads(result.stdout)
+        if not items:
+            return None
 
-    Returns a formatted string summarizing community activity, or empty
-    string if nothing found or gh CLI unavailable.
-    """
-    sections = []
+        lines = [f"### Recent {label}"]
+        for item in items[:10]:
+            title = item.get("title", "")
+            state = item.get("state", "")
+            comments = item.get("comments", 0)
+            labels = ", ".join(l.get("name", "") for l in item.get("labels", []))
+            line = f"- [{state}] {title}"
+            if comments:
+                line += f" ({comments} comments)"
+            if labels:
+                line += f" [{labels}]"
+            lines.append(line)
+        return "\n".join(lines)
+    except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
+        return None
 
-    for endpoint, label in [
-        ("issues?state=all&per_page=20&sort=updated&direction=desc", "Issues"),
-        ("pulls?state=all&per_page=10&sort=updated&direction=desc", "Pull Requests"),
-    ]:
-        try:
-            result = subprocess.run(
-                ["gh", "api", f"repos/donjguido/ai-dictionary/{endpoint}"],
-                capture_output=True, text=True, timeout=15, cwd=REPO_ROOT,
-            )
-            if result.returncode != 0:
-                continue
-            items = json.loads(result.stdout)
-            if not items:
-                continue
 
-            lines = [f"### Recent {label}"]
-            for item in items[:10]:
-                title = item.get("title", "")
-                state = item.get("state", "")
-                comments = item.get("comments", 0)
-                labels = ", ".join(l.get("name", "") for l in item.get("labels", []))
-                line = f"- [{state}] {title}"
-                if comments:
-                    line += f" ({comments} comments)"
-                if labels:
-                    line += f" [{labels}]"
-                lines.append(line)
-            sections.append("\n".join(lines))
-        except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
-            continue
-
-    # Try discussions (GraphQL)
+def _fetch_discussions() -> str | None:
+    """Fetch discussions via GraphQL."""
     try:
         query = '{ repository(owner: "donjguido", name: "ai-dictionary") { discussions(first: 15, orderBy: {field: UPDATED_AT, direction: DESC}) { nodes { title, category { name }, comments { totalCount }, upvoteCount } } } }'
         result = subprocess.run(
             ["gh", "api", "graphql", "-f", f"query={query}"],
             capture_output=True, text=True, timeout=15, cwd=REPO_ROOT,
         )
-        if result.returncode == 0:
-            data = json.loads(result.stdout)
-            discussions = data.get("data", {}).get("repository", {}).get("discussions", {}).get("nodes", [])
-            if discussions:
-                lines = ["### Recent Discussions"]
-                for d in discussions:
-                    title = d.get("title", "")
-                    cat = d.get("category", {}).get("name", "")
-                    comments = d.get("comments", {}).get("totalCount", 0)
-                    upvotes = d.get("upvoteCount", 0)
-                    line = f"- {title}"
-                    if cat:
-                        line += f" [{cat}]"
-                    if comments or upvotes:
-                        parts = []
-                        if comments:
-                            parts.append(f"{comments} comments")
-                        if upvotes:
-                            parts.append(f"{upvotes} upvotes")
-                        line += f" ({', '.join(parts)})"
-                    lines.append(line)
-                sections.append("\n".join(lines))
+        if result.returncode != 0:
+            return None
+        data = json.loads(result.stdout)
+        discussions = data.get("data", {}).get("repository", {}).get("discussions", {}).get("nodes", [])
+        if not discussions:
+            return None
+
+        lines = ["### Recent Discussions"]
+        for d in discussions:
+            title = d.get("title", "")
+            cat = d.get("category", {}).get("name", "")
+            comments = d.get("comments", {}).get("totalCount", 0)
+            upvotes = d.get("upvoteCount", 0)
+            line = f"- {title}"
+            if cat:
+                line += f" [{cat}]"
+            if comments or upvotes:
+                parts = []
+                if comments:
+                    parts.append(f"{comments} comments")
+                if upvotes:
+                    parts.append(f"{upvotes} upvotes")
+                line += f" ({', '.join(parts)})"
+            lines.append(line)
+        return "\n".join(lines)
     except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
-        pass
+        return None
+
+
+def fetch_community_activity() -> str:
+    """Fetch recent GitHub discussions, issues, and PRs in parallel.
+
+    Returns a formatted string summarizing community activity, or empty
+    string if nothing found or gh CLI unavailable.
+    """
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        futures = {
+            executor.submit(_fetch_rest_endpoint, "issues?state=all&per_page=20&sort=updated&direction=desc", "Issues"): "issues",
+            executor.submit(_fetch_rest_endpoint, "pulls?state=all&per_page=10&sort=updated&direction=desc", "Pull Requests"): "pulls",
+            executor.submit(_fetch_discussions): "discussions",
+        }
+        sections = []
+        for future in as_completed(futures):
+            try:
+                result = future.result()
+                if result:
+                    sections.append(result)
+            except Exception:
+                continue
 
     if not sections:
         return ""
@@ -643,23 +661,27 @@ def main():
     active = [p for p in available if p["is_available"]]
     print(f"Available providers: {', '.join(p['name'] for p in active) or 'none!'}")
 
-    # Load definitions
-    all_defs = load_definitions()
+    # Gather all input data in parallel
+    print("Loading definitions, community activity, tag evolution...")
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        future_defs = executor.submit(load_definitions)
+        future_prev = executor.submit(get_previous_summary)
+        future_community = executor.submit(fetch_community_activity)
+        future_tags = executor.submit(get_tag_evolution)
+
+    all_defs = future_defs.result()
     print(f"Loaded {len(all_defs)} definitions")
 
-    # Load previous summary for changelog
-    previous = get_previous_summary()
+    previous = future_prev.result()
     if previous:
         changelog = CHANGELOG_SECTION_TEMPLATE.format(
             count=len(all_defs),
-            previous_summary=previous[:3000],  # Truncate to save tokens
+            previous_summary=previous[:3000],
         )
     else:
         changelog = CHANGELOG_FIRST_TIME
 
-    # Gather community activity (discussions, issues, PRs)
-    print("Fetching community activity...")
-    community = fetch_community_activity()
+    community = future_community.result()
     if community:
         community_section = f"""## Community Pulse
 
@@ -671,9 +693,8 @@ The following recent activity from GitHub discussions, issues, and pull requests
         community_section = ""
         print("No community activity found (discussions/issues/PRs)")
 
-    # Gather tag evolution data
-    print("Analyzing tag evolution...")
-    tag_evolution = get_tag_evolution()
+    tag_evolution = future_tags.result()
+    print("Tag evolution analyzed")
     tag_evolution_section = f"""## Tag Taxonomy Context
 
 The dictionary uses a tag system to organize definitions. Here is the current state of tags. Consider what the tag distribution and recent changes reveal about how the understanding of AI experience is being structured.


### PR DESCRIPTION
## Summary

- **consensus.py**: Process multiple terms concurrently (up to 4 at once) on top of existing per-model parallelism — two-level concurrency for ~65-75% faster consensus runs
- **build_api.py**: Run 5 independent build phases in parallel (consensus, census, reputation, vitality, discussions); parallelize definition parsing and term/citation file writes with ThreadPoolExecutor
- **executive_summary.py**: Fetch Issues, PRs, and Discussions endpoints concurrently (~3x faster API portion); gather all input data in parallel before the LLM call
- **process-votes.yml**: Close/comment on processed and failed issues concurrently instead of sequentially

## Test plan

- [ ] Run consensus workflow and verify consensus-data JSON files are written correctly
- [ ] Run build-api workflow and verify all API JSON output is valid
- [ ] Run executive-summary workflow and verify summary generation completes
- [ ] Trigger process-votes sweep and verify issues are closed correctly
- [ ] Check no race conditions in file writes (each term writes to its own file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)