### PR TITLE
Fix missing providers_file in LLMRouter initialization

### DIFF
--- a/bot/executive_summary.py
+++ b/bot/executive_summary.py
@@ -779,6 +779,7 @@ def update_readme_with_frontiers():
 def main():
     # Initialize LLM Router
     router = LLMRouter(
+        providers_file=str(API_CONFIG_DIR / "providers.yml"),
         profiles_file=str(API_CONFIG_DIR / "profiles.yml"),
         tracker_file=str(API_CONFIG_DIR / "tracker-state.json"),
     )

--- a/bot/generate.py
+++ b/bot/generate.py
@@ -421,6 +421,7 @@ def process_definitions(
 def main():
     # Initialize LLM Router
     router = LLMRouter(
+        providers_file=str(API_CONFIG_DIR / "providers.yml"),
         profiles_file=str(API_CONFIG_DIR / "profiles.yml"),
         tracker_file=str(API_CONFIG_DIR / "tracker-state.json"),
     )

--- a/bot/propose_generated_term.py
+++ b/bot/propose_generated_term.py
@@ -308,6 +308,7 @@ def main():
 
     # ── Initialize router ───────────────────────────────────────────────
     router = LLMRouter(
+        providers_file=str(API_CONFIG_DIR / "providers.yml"),
         profiles_file=str(API_CONFIG_DIR / "profiles.yml"),
         tracker_file=str(API_CONFIG_DIR / "tracker-state.json"),
     )

--- a/bot/review_pr.py
+++ b/bot/review_pr.py
@@ -41,6 +41,7 @@ def main():
 
     # Initialize LLM Router for verification
     router = LLMRouter(
+        providers_file=str(API_CONFIG_DIR / "providers.yml"),
         profiles_file=str(API_CONFIG_DIR / "profiles.yml"),
         tracker_file=str(API_CONFIG_DIR / "tracker-state.json"),
     )

--- a/bot/review_submission.py
+++ b/bot/review_submission.py
@@ -648,6 +648,7 @@ def main():
     # ── Step 3: Quality evaluation (LLM) ─────────────────────────────────
 
     router = LLMRouter(
+        providers_file=str(API_CONFIG_DIR / "providers.yml"),
         profiles_file=str(API_CONFIG_DIR / "profiles.yml"),
         tracker_file=str(API_CONFIG_DIR / "tracker-state.json"),
     )

--- a/bot/tag_review.py
+++ b/bot/tag_review.py
@@ -107,6 +107,7 @@ def apply_changes(changes: list[dict]):
 def main():
     # Initialize LLM Router
     router = LLMRouter(
+        providers_file=str(API_CONFIG_DIR / "providers.yml"),
         profiles_file=str(API_CONFIG_DIR / "profiles.yml"),
         tracker_file=str(API_CONFIG_DIR / "tracker-state.json"),
     )


### PR DESCRIPTION
Six bot scripts were only passing profiles_file but not providers_file to LLMRouter(), so the custom deepseek provider defined in bot/api-config/providers.yml was never loaded. This caused warnings about generate-deepseek and consensus-deepseek referencing an unknown provider. Only consensus.py had it correct.