### PR TITLE
Fix sidebar bottom items hidden on narrow screens

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1949,7 +1949,7 @@ html[data-theme="dark"] .theme-toggle .theme-icon-dark { display: inline; }
     }
 
     .sidebar-nav {
-        height: 100vh;
+        height: calc(100vh - 3rem);
         overflow-y: auto;
     }
 


### PR DESCRIPTION
## Summary
- The sidebar nav height was `100vh` but didn't account for the sidebar's `1.5rem` top+bottom padding
- GitHub link and dark mode toggle were pushed off-screen
- Changed to `calc(100vh - 3rem)` so all items remain visible and scrollable

## Test plan
- [ ] Resize to 769–1100px, open sidebar via arrow tab
- [ ] Verify GitHub link and theme toggle are visible at the bottom
- [ ] Verify sidebar content scrolls if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)