### PR TITLE
Add hover lift effect to frontier cards

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -744,6 +744,13 @@ code {
     border-radius: var(--radius);
     padding: 1.25rem 1.5rem;
     margin-bottom: 1rem;
+    cursor: pointer;
+    transition: box-shadow 0.2s, transform 0.15s;
+}
+
+.frontier-card:hover {
+    box-shadow: 0 4px 12px var(--shadow);
+    transform: translateY(-1px);
 }
 
 .frontier-card h3 {
@@ -797,16 +804,6 @@ code {
 
 .frontier-checkin .checkin-meta {
     font-weight: 600;
-}
-
-.frontier-clickable {
-    cursor: pointer;
-    transition: border-color 0.15s, box-shadow 0.15s;
-}
-
-.frontier-clickable:hover {
-    border-color: var(--purple);
-    box-shadow: 0 2px 8px var(--shadow);
 }
 
 .frontier-checkin-preview {


### PR DESCRIPTION
## Summary
- Frontier cards now have the same hover lift effect as term cards (`translateY(-1px)` + `box-shadow`)
- Consolidated duplicate hover styles into the base `.frontier-card` class

## Test plan
- [ ] Hover over a frontier card — subtle lift and shadow appears

Generated with [Claude Code](https://claude.com/claude-code)