### PR TITLE
Fix sidebar bottom items layout on narrow screens

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -68,7 +68,6 @@
 
     <div class="layout">
     <aside class="sidebar" id="sidebar">
-        <div class="sidebar-tab" aria-hidden="true">&#9654;</div>
         <nav class="sidebar-nav" id="sidebar-nav">
             <a href="#about" class="sidebar-link" data-section="about">About</a>
             <a href="#new-words" class="sidebar-link" data-section="new-words">New</a>
@@ -88,6 +87,7 @@
                 <span class="theme-icon-dark">&#9788;</span>
             </button>
         </nav>
+        <div class="sidebar-tab" aria-hidden="true">&#9654;</div>
     </aside>
     <div class="sidebar-backdrop" id="sidebar-backdrop"></div>
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -1945,18 +1945,24 @@ html[data-theme="dark"] .theme-toggle .theme-icon-dark { display: inline; }
 /* Narrow desktop / tablet — collapse sidebar behind an arrow tab */
 @media (max-width: 1100px) and (min-width: 769px) {
     .sidebar {
-        overflow: visible;
+        display: flex;
+        width: 248px;
+        padding: 0;
+        overflow: hidden;
     }
 
     .sidebar-nav {
-        height: calc(100vh - 3rem);
+        width: 220px;
+        flex-shrink: 0;
+        height: 100vh;
         overflow-y: auto;
+        padding: 1.5rem 0;
     }
 
     .sidebar.visible {
         opacity: 1;
         pointer-events: auto;
-        transform: translateX(-100%);
+        transform: translateX(-220px);
         transition: transform 0.25s ease;
     }
 
@@ -1973,29 +1979,21 @@ html[data-theme="dark"] .theme-toggle .theme-icon-dark { display: inline; }
         display: flex;
         align-items: center;
         justify-content: center;
-        position: absolute;
-        top: 50%;
-        right: -28px;
-        transform: translateY(-50%);
         width: 28px;
-        height: 48px;
+        flex-shrink: 0;
         background: var(--bg-secondary);
-        border: 1px solid var(--border);
-        border-left: none;
-        border-radius: 0 var(--radius) var(--radius) 0;
+        border-left: 1px solid var(--border);
         color: var(--text-secondary);
         font-size: 0.7rem;
         opacity: 0.3;
         cursor: pointer;
         transition: opacity 0.2s ease;
-        box-shadow: 2px 0 6px var(--shadow);
     }
 
     .sidebar-tab:hover {
         opacity: 1;
     }
 
-    /* Hide border-right seam when collapsed */
     .sidebar.visible:not(:hover) {
         border-right-color: transparent;
     }


### PR DESCRIPTION
## Summary
- Restructured the medium-breakpoint (769–1100px) sidebar as a **flex row**: nav (220px, scrollable) + arrow tab (28px)
- Sidebar translates by `220px` instead of `100%`, hiding only the nav while the tab remains visible
- Removes `overflow: visible` hack that was causing the GitHub link and theme toggle to display incorrectly
- Moved `.sidebar-tab` after `.sidebar-nav` in HTML so it naturally sits on the right in the flex layout

## Test plan
- [ ] Resize to 769–1100px — arrow tab visible on left edge, faded
- [ ] Hover tab — fills to full opacity, sidebar slides in
- [ ] GitHub link and theme toggle visible at bottom of sidebar nav
- [ ] Wide screens (>1100px) — original faded sidebar behavior unchanged
- [ ] Mobile (<769px) — hamburger menu unchanged
- [ ] Both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)