### PR TITLE
Fade out section content before collapsing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -698,8 +698,15 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
             content.classList.remove('collapsed');
             header.setAttribute('aria-expanded', 'true');
         } else {
-            content.classList.add('collapsed');
+            // Fade out content, then collapse
+            content.classList.add('fading-out');
             header.setAttribute('aria-expanded', 'false');
+            content.addEventListener('transitionend', function handler(e) {
+                if (e.propertyName !== 'opacity') return;
+                content.removeEventListener('transitionend', handler);
+                content.classList.remove('fading-out');
+                content.classList.add('collapsed');
+            }, { once: false });
         }
 
         // Persist

--- a/docs/style.css
+++ b/docs/style.css
@@ -313,6 +313,10 @@ section { margin-bottom: 4rem; }
     transition: opacity 0.25s ease;
 }
 
+.section-content.fading-out {
+    opacity: 0;
+}
+
 .section-content.collapsed {
     max-height: 0;
     opacity: 0;


### PR DESCRIPTION
## Summary
- When a collapsible section is closed, the content now fades out (opacity transition) before the height collapses
- Adds a `fading-out` CSS class that triggers the opacity transition, then swaps to `collapsed` after the transition completes
- Expanding sections already fade in via the existing opacity transition

## Test plan
- [ ] Click a section header to collapse it — content should fade out smoothly, then the section closes
- [ ] Click to expand — content should fade in
- [ ] Rapidly toggle a section open/closed to ensure no stuck states

🤖 Generated with [Claude Code](https://claude.com/claude-code)