### PR TITLE
Fix sidebar nav items wrapping into two columns

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -206,6 +206,7 @@ nav a:hover { color: var(--primary); }
 .sidebar-nav {
     display: flex;
     flex-direction: column;
+    flex-wrap: nowrap;
 }
 
 .sidebar-link {


### PR DESCRIPTION
## Summary
- The `nav` element selector sets `flex-wrap: wrap` for the top navigation bar
- The sidebar nav (`<nav class="sidebar-nav">`) inherits this, causing items to wrap into a second column when viewport height is short
- Added `flex-wrap: nowrap` to `.sidebar-nav` so items always stack vertically and scroll

## Test plan
- [ ] Resize browser to a short viewport — sidebar items should be in a single column with vertical scroll
- [ ] No horizontal scrollbar in the sidebar
- [ ] Top navigation bar still wraps correctly on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)