### PR TITLE
Hide top nav on small screens

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -2128,8 +2128,7 @@ html[data-theme="dark"] .theme-toggle .theme-icon-dark { display: inline; }
 @media (max-width: 768px) {
     header h1 { font-size: 2rem; }
     header .tagline { font-size: 1.1rem; }
-    nav { gap: 1rem; padding: 0.75rem 1rem; }
-    nav.nav-hidden { opacity: 1; pointer-events: auto; }
+    nav#top-nav { display: none; }
     main { padding: 1.5rem 1rem; }
 
     .sidebar {


### PR DESCRIPTION
## Summary
- Hide the top navigation bar on screens ≤768px so only the hamburger menu is available for navigation
- Previously the top nav remained visible on mobile alongside the hamburger, creating redundant navigation

## Test plan
- [ ] Resize browser to ≤768px and verify top nav bar is hidden
- [ ] Verify hamburger menu still appears and opens the sidebar
- [ ] Verify top nav still works normally on wider screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)