### PR TITLE
Restore subtle arrow tab style on narrow screens

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1980,15 +1980,20 @@ html[data-theme="dark"] .theme-toggle .theme-icon-dark { display: inline; }
         display: flex;
         align-items: center;
         justify-content: center;
+        align-self: center;
         width: 28px;
+        height: 48px;
         flex-shrink: 0;
         background: var(--bg-secondary);
-        border-left: 1px solid var(--border);
+        border: 1px solid var(--border);
+        border-left: none;
+        border-radius: 0 var(--radius) var(--radius) 0;
         color: var(--text-secondary);
         font-size: 0.7rem;
         opacity: 0.3;
         cursor: pointer;
         transition: opacity 0.2s ease;
+        box-shadow: 2px 0 6px var(--shadow);
     }
 
     .sidebar-tab:hover {


### PR DESCRIPTION
## Summary
- Arrow tab is now a small 48px rounded pill centered vertically (instead of a full-height bar)
- Soft box-shadow, rounded right corners, faded to 0.3 opacity
- Fills in on hover, matching the original inconspicuous design

## Test plan
- [ ] Resize to 769–1100px — small grey arrow visible at left edge, faded
- [ ] Hover — arrow fills to full opacity
- [ ] Continue into sidebar — slides in, arrow fades out

🤖 Generated with [Claude Code](https://claude.com/claude-code)