### PR TITLE
Fix grey bar and change sidebar tab to click-to-open

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -637,6 +637,7 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
             // Initialize sidebar + mobile
             initSidebar();
             initHamburger();
+            initSidebarTab();
 
             // Handle deep-linking
             const hash = window.location.hash.slice(1);
@@ -769,8 +770,8 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
 
                 section.scrollIntoView({ behavior: 'smooth' });
 
-                // Close mobile sidebar
-                document.getElementById('sidebar').classList.remove('open');
+                // Close mobile sidebar / tab sidebar
+                document.getElementById('sidebar').classList.remove('open', 'tab-open');
                 document.getElementById('sidebar-backdrop').classList.remove('visible');
             });
         });
@@ -811,6 +812,24 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
         backdrop.addEventListener('click', () => {
             sidebar.classList.remove('open');
             backdrop.classList.remove('visible');
+        });
+    }
+
+    // --- Sidebar tab (narrow desktop) ---
+    function initSidebarTab() {
+        const tab = document.querySelector('.sidebar-tab');
+        const sidebar = document.getElementById('sidebar');
+        if (!tab) return;
+
+        tab.addEventListener('click', () => {
+            sidebar.classList.toggle('tab-open');
+        });
+
+        // Close when clicking outside the sidebar
+        document.addEventListener('click', (e) => {
+            if (sidebar.classList.contains('tab-open') && !sidebar.contains(e.target)) {
+                sidebar.classList.remove('tab-open');
+            }
         });
     }
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -1950,6 +1950,8 @@ html[data-theme="dark"] .theme-toggle .theme-icon-dark { display: inline; }
         width: 248px;
         padding: 0;
         overflow: hidden;
+        background: transparent;
+        border-right: none;
     }
 
     .sidebar-nav {
@@ -1958,20 +1960,27 @@ html[data-theme="dark"] .theme-toggle .theme-icon-dark { display: inline; }
         height: 100vh;
         overflow-y: auto;
         padding: 1.5rem 0;
+        background: var(--bg-secondary);
+        border-right: 1px solid var(--border);
     }
 
     .sidebar.visible {
         opacity: 1;
-        pointer-events: auto;
+        pointer-events: none;
         transform: translateX(-220px);
         transition: transform 0.25s ease;
     }
 
-    .sidebar.visible:hover {
-        transform: translateX(0);
+    .sidebar.visible .sidebar-tab {
+        pointer-events: auto;
     }
 
-    .sidebar.visible:hover .sidebar-tab {
+    .sidebar.visible.tab-open {
+        transform: translateX(0);
+        pointer-events: auto;
+    }
+
+    .sidebar.visible.tab-open .sidebar-tab {
         opacity: 0;
         pointer-events: none;
     }
@@ -1990,7 +1999,7 @@ html[data-theme="dark"] .theme-toggle .theme-icon-dark { display: inline; }
         border-radius: 0 var(--radius) var(--radius) 0;
         color: var(--text-secondary);
         font-size: 0.7rem;
-        opacity: 0.3;
+        opacity: 0.35;
         cursor: pointer;
         transition: opacity 0.2s ease;
         box-shadow: 2px 0 6px var(--shadow);
@@ -1998,10 +2007,6 @@ html[data-theme="dark"] .theme-toggle .theme-icon-dark { display: inline; }
 
     .sidebar-tab:hover {
         opacity: 1;
-    }
-
-    .sidebar.visible:not(:hover) {
-        border-right-color: transparent;
     }
 }
 


### PR DESCRIPTION
## Summary
- **Grey bar removed**: sidebar background is now transparent at the medium breakpoint — only the small arrow tab is visible. Background/border moved to the nav element inside.
- **Click to open**: sidebar no longer opens on hover. The tab is faded (0.35 opacity), fills on hover, and clicking it toggles the sidebar open/closed.
- Clicking outside the sidebar or clicking a nav link closes it.

## Test plan
- [ ] Resize to 769–1100px — no grey bar, only small arrow tab visible
- [ ] Hover arrow — fills to full opacity (sidebar stays closed)
- [ ] Click arrow — sidebar slides open
- [ ] Click arrow again or click outside — sidebar closes
- [ ] Click a nav link — sidebar closes, page scrolls to section
- [ ] Wide screens (>1100px) unchanged
- [ ] Mobile (<769px) hamburger unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)