### PR TITLE
Keep arrow tab visible when sidebar is open, flip to close

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1981,8 +1981,8 @@ html[data-theme="dark"] .theme-toggle .theme-icon-dark { display: inline; }
     }
 
     .sidebar.visible.tab-open .sidebar-tab {
-        opacity: 0;
-        pointer-events: none;
+        opacity: 0.5;
+        transform: scaleX(-1);
     }
 
     .sidebar-tab {


### PR DESCRIPTION
## Summary
- Arrow tab stays visible (0.5 opacity) when sidebar is open — click it to close
- Arrow flips to point inward (left) when open, indicating "close"
- Still brightens to full opacity on hover

## Test plan
- [ ] Click arrow to open sidebar — arrow stays visible, flips to point left
- [ ] Click arrow again — sidebar closes, arrow flips back to point right
- [ ] Hover arrow when open — fills to full opacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)