### PR TITLE
Ensure full opacity on hover for close arrow

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1985,6 +1985,10 @@ html[data-theme="dark"] .theme-toggle .theme-icon-dark { display: inline; }
         transform: scaleX(-1);
     }
 
+    .sidebar.visible.tab-open .sidebar-tab:hover {
+        opacity: 1;
+    }
+
     .sidebar-tab {
         display: flex;
         align-items: center;


### PR DESCRIPTION
## Summary
- The flipped close arrow was stuck at 0.5 opacity on hover due to CSS specificity
- Added a higher-specificity hover rule so it fills to full opacity

## Test plan
- [ ] Open sidebar via arrow tab, hover the flipped close arrow — should be fully opaque

🤖 Generated with [Claude Code](https://claude.com/claude-code)