### PR TITLE
Make mobile hamburger menu transparent until hovered

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -2188,6 +2188,13 @@ html[data-theme="dark"] .theme-toggle .theme-icon-dark { display: inline; }
         padding: 8px;
         cursor: pointer;
         box-shadow: 0 2px 8px var(--shadow);
+        opacity: 0.08;
+        transition: opacity 0.25s ease;
+    }
+
+    .hamburger:hover,
+    .hamburger:focus-visible {
+        opacity: 1;
     }
 
     .hamburger span {


### PR DESCRIPTION
## Summary
- Sets the mobile hamburger menu button to near-invisible (`opacity: 0.08`) by default
- Fades to fully visible on hover or keyboard focus (`focus-visible`)
- Keeps the menu accessible without cluttering the mobile UI

## Test plan
- [ ] View on a narrow viewport (< mobile breakpoint) and confirm the hamburger is barely visible
- [ ] Hover over the hamburger area and confirm it becomes fully opaque
- [ ] Tab to the hamburger and confirm it becomes visible via `focus-visible`

🤖 Generated with [Claude Code](https://claude.com/claude-code)