### PR TITLE
Add racecar border hover animation to index cards

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1,5 +1,11 @@
 /* AI Dictionary — Style Sheet */
 
+@property --race {
+    syntax: '<angle>';
+    initial-value: 0deg;
+    inherits: false;
+}
+
 :root {
     --primary: #2563eb;
     --primary-dark: #1e40af;
@@ -2066,6 +2072,50 @@ html[data-theme="dark"] .badge-trusted { background: #3b0764; color: #c4b5fd; }
 
 html:not([data-theme="dark"]) .theme-toggle .theme-icon-light { display: inline; }
 html[data-theme="dark"] .theme-toggle .theme-icon-dark { display: inline; }
+
+/* Racecar border hover — colored side races around the full border */
+.frontier-card:not(.frontier-completed),
+.wotd-hero,
+.new-word-card,
+.summary-card {
+    --card-accent: var(--purple);
+    position: relative;
+    z-index: 0;
+}
+.new-word-card  { --card-accent: var(--green); }
+.summary-card   { --card-accent: var(--primary); }
+
+.frontier-card:not(.frontier-completed)::after,
+.wotd-hero::after,
+.new-word-card::after,
+.summary-card::after {
+    content: '';
+    position: absolute;
+    inset: -2px;
+    border-radius: inherit;
+    padding: 3px;
+    background: conic-gradient(
+        from 270deg,
+        var(--card-accent) var(--race),
+        transparent var(--race)
+    );
+    -webkit-mask:
+        linear-gradient(#fff 0 0) content-box,
+        linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    pointer-events: none;
+    --race: 0deg;
+    transition: --race 0.45s ease-in;
+}
+
+.frontier-card:not(.frontier-completed):hover::after,
+.wotd-hero:hover::after,
+.new-word-card:hover::after,
+.summary-card:hover::after {
+    --race: 360deg;
+    transition: --race 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
 
 /* Responsive */
 /* Narrow desktop / tablet — collapse sidebar behind an arrow tab */


### PR DESCRIPTION
## Summary
- Cards with colored left borders (frontier, word-of-the-day, new-word, summary) now sweep the accent color around the full border on hover
- Uses `@property --race` with an animated `conic-gradient` masked to a 3px border ring
- The sweep starts at the left side (270deg) and races clockwise with a fast-start easing curve; on mouse-out it unwinds back
- Completed frontier cards are excluded from the effect

## Test plan
- [ ] Hover over frontier cards — purple border should race around clockwise
- [ ] Hover over word-of-the-day hero — same purple race effect
- [ ] Hover over new-word cards — green border races around
- [ ] Hover over summary cards — blue border races around
- [ ] Mouse out — border should unwind/retract smoothly
- [ ] Completed frontier cards should have no effect
- [ ] Verify dark mode works correctly
- [ ] Check mobile — no layout shift from the pseudo-element

🤖 Generated with [Claude Code](https://claude.com/claude-code)