### PR TITLE
Fix nav/sidebar flash during scroll transition

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -154,7 +154,7 @@ nav {
     position: sticky;
     top: 0;
     z-index: 100;
-    transition: opacity 0.3s ease;
+    /* No transition — toggle is instant to stay in sync with sidebar */
 }
 
 nav.nav-hidden {
@@ -191,12 +191,13 @@ nav a:hover { color: var(--primary); }
     z-index: 150;
     opacity: 0;
     pointer-events: none;
-    transition: opacity 0.3s ease;
+    /* No transition here — show/hide toggle is instant to avoid flash */
 }
 
 .sidebar.visible {
     opacity: 0.3;
     pointer-events: auto;
+    transition: opacity 0.3s ease; /* Only animates hover in/out within visible state */
 }
 
 .sidebar.visible:hover {


### PR DESCRIPTION
## Summary
- Remove opacity transitions from nav and sidebar show/hide toggles so they switch instantly when the IntersectionObserver fires
- The 0.3s fade on both elements caused a visible flash near the header boundary where both were partially visible simultaneously
- Sidebar hover fade (0.3 → 1 opacity) still animates smoothly via transition on `.sidebar.visible`

## Test plan
- [ ] Scroll slowly down past the header — sidebar should appear instantly without flashing
- [ ] Scroll slowly back up to the header — sidebar should disappear instantly, nav should appear without both being visible
- [ ] Hover over the sidebar when visible — should still smoothly fade from 0.3 to 1 opacity
- [ ] Verify on mobile that sidebar/hamburger behavior is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)