### PR TITLE
Match racecar border width to the left accent border

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -2091,9 +2091,9 @@ html[data-theme="dark"] .theme-toggle .theme-icon-dark { display: inline; }
 .summary-card::after {
     content: '';
     position: absolute;
-    inset: -2px;
+    inset: -1px;
     border-radius: inherit;
-    padding: 3px;
+    padding: 2px;
     background: conic-gradient(
         from 270deg,
         var(--card-accent) var(--race),


### PR DESCRIPTION
Reduce pseudo-element padding from 3px to 2px and inset from -2px to -1px so the racing line is the same visual weight as the 4px left border.