### PR TITLE
Add animated h2 underline hover effect

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -335,8 +335,25 @@ h2 {
     font-size: 1.75rem;
     margin-bottom: 1rem;
     color: var(--text);
-    border-bottom: 3px solid var(--primary);
+    border-bottom: none;
     padding-bottom: 0.4rem;
+    position: relative;
+}
+
+h2::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 40%;
+    height: 3px;
+    background: var(--primary);
+    transition: width 0.4s ease, background 0.4s ease;
+}
+
+h2:hover::after {
+    width: 100%;
+    background: var(--purple);
 }
 
 h3 { font-size: 1.25rem; margin-bottom: 0.5rem; }


### PR DESCRIPTION
## Summary
- H2 underlines now start at 40% width instead of full width
- On hover, the underline smoothly expands to 100% width and shifts from primary blue to purple
- Transition uses 0.4s ease for a polished feel

## Test plan
- [ ] Verify h2 underlines appear shorter by default on the index page
- [ ] Hover over section headers and confirm the line expands to full width
- [ ] Confirm the color transitions from blue to purple on hover
- [ ] Check both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)