### PR TITLE
Trigger h2 underline animation when hovering section-header area

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -351,6 +351,7 @@ h2::after {
     transition: width 0.4s ease, background 0.4s ease;
 }
 
+.section-header:hover h2::after,
 h2:hover::after {
     width: 100%;
     background: var(--purple);


### PR DESCRIPTION
Hovering the toggle chevron/arrow now also expands the underline, since the hover targets the parent .section-header container.