### PR TITLE
Add animated slide-switch theme toggle

### DIFF
--- a/docs/for-machines/index.html
+++ b/docs/for-machines/index.html
@@ -246,8 +246,11 @@
         <span class="spacer"></span>
         <a href="index.json">JSON</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
-            <span class="theme-icon-light">&#9790;</span>
-            <span class="theme-icon-dark">&#9788;</span>
+            <div class="theme-switch">
+                <span class="theme-switch-icon theme-switch-icon-sun">&#9788;</span>
+                <span class="theme-switch-icon theme-switch-icon-moon">&#9790;</span>
+                <div class="theme-switch-knob"></div>
+            </div>
         </button>
     </nav>
 
@@ -1128,13 +1131,20 @@ POST /discuss
     <script>
         // Theme toggle
         function initThemeToggle() {
+            let transitionTimeout;
             const toggles = document.querySelectorAll('.theme-toggle');
             toggles.forEach(function(btn) {
                 btn.addEventListener('click', function() {
-                    const current = document.documentElement.getAttribute('data-theme');
+                    const root = document.documentElement;
+                    const current = root.getAttribute('data-theme');
                     const next = current === 'dark' ? 'light' : 'dark';
-                    document.documentElement.setAttribute('data-theme', next);
+                    clearTimeout(transitionTimeout);
+                    root.classList.add('theme-transitioning');
+                    root.setAttribute('data-theme', next);
                     localStorage.setItem('theme', next);
+                    transitionTimeout = setTimeout(function() {
+                        root.classList.remove('theme-transitioning');
+                    }, 600);
                 });
             });
         }

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,8 +57,11 @@
         <a href="/for-machines/">For Machines</a>
         <a href="https://github.com/donjguido/ai-dictionary" target="_blank">GitHub</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
-            <span class="theme-icon-light">&#9790;</span>
-            <span class="theme-icon-dark">&#9788;</span>
+            <div class="theme-switch">
+                <span class="theme-switch-icon theme-switch-icon-sun">&#9788;</span>
+                <span class="theme-switch-icon theme-switch-icon-moon">&#9790;</span>
+                <div class="theme-switch-knob"></div>
+            </div>
         </button>
     </nav>
 
@@ -83,8 +86,11 @@
             <a href="/for-machines/" class="sidebar-link">For Machines</a>
             <a href="https://github.com/donjguido/ai-dictionary" target="_blank" class="sidebar-link sidebar-link-external">GitHub</a>
             <button class="theme-toggle" id="sidebar-theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode" style="margin:0.75rem 1.25rem;">
-                <span class="theme-icon-light">&#9790;</span>
-                <span class="theme-icon-dark">&#9788;</span>
+                <div class="theme-switch">
+                    <span class="theme-switch-icon theme-switch-icon-sun">&#9788;</span>
+                    <span class="theme-switch-icon theme-switch-icon-moon">&#9790;</span>
+                    <div class="theme-switch-knob"></div>
+                </div>
             </button>
         </nav>
         <div class="sidebar-tab" aria-hidden="true">&#9654;</div>
@@ -525,15 +531,24 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
     <script>
     // Theme toggle
     (function() {
+        var transitionTimeout;
         function toggleTheme() {
-            var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+            var root = document.documentElement;
+            var isDark = root.getAttribute('data-theme') === 'dark';
+            // Add transition class for smooth color change
+            clearTimeout(transitionTimeout);
+            root.classList.add('theme-transitioning');
             if (isDark) {
-                document.documentElement.removeAttribute('data-theme');
+                root.removeAttribute('data-theme');
                 localStorage.setItem('theme', 'light');
             } else {
-                document.documentElement.setAttribute('data-theme', 'dark');
+                root.setAttribute('data-theme', 'dark');
                 localStorage.setItem('theme', 'dark');
             }
+            // Remove transition class after animation completes
+            transitionTimeout = setTimeout(function() {
+                root.classList.remove('theme-transitioning');
+            }, 600);
         }
         document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
         document.getElementById('sidebar-theme-toggle').addEventListener('click', toggleTheme);

--- a/docs/moderation/index.html
+++ b/docs/moderation/index.html
@@ -218,8 +218,11 @@
         <span class="spacer"></span>
         <a href="https://ai-dictionary-proxy.phenomenai.workers.dev/api/moderation-criteria">JSON</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
-            <span class="theme-icon-light">&#9790;</span>
-            <span class="theme-icon-dark">&#9788;</span>
+            <div class="theme-switch">
+                <span class="theme-switch-icon theme-switch-icon-sun">&#9788;</span>
+                <span class="theme-switch-icon theme-switch-icon-moon">&#9790;</span>
+                <div class="theme-switch-knob"></div>
+            </div>
         </button>
     </nav>
 
@@ -762,13 +765,20 @@
 
     <script>
         function initThemeToggle() {
+            var transitionTimeout;
             var toggles = document.querySelectorAll('.theme-toggle');
             toggles.forEach(function(btn) {
                 btn.addEventListener('click', function() {
-                    var current = document.documentElement.getAttribute('data-theme');
+                    var root = document.documentElement;
+                    var current = root.getAttribute('data-theme');
                     var next = current === 'dark' ? 'light' : 'dark';
-                    document.documentElement.setAttribute('data-theme', next);
+                    clearTimeout(transitionTimeout);
+                    root.classList.add('theme-transitioning');
+                    root.setAttribute('data-theme', next);
                     localStorage.setItem('theme', next);
+                    transitionTimeout = setTimeout(function() {
+                        root.classList.remove('theme-transitioning');
+                    }, 600);
                 });
             });
         }

--- a/docs/style.css
+++ b/docs/style.css
@@ -30,6 +30,13 @@
     --radius: 8px;
 }
 
+html.theme-transitioning,
+html.theme-transitioning *,
+html.theme-transitioning *::before,
+html.theme-transitioning *::after {
+    transition: background-color 0.5s ease, color 0.4s ease, border-color 0.4s ease, box-shadow 0.4s ease !important;
+}
+
 html[data-theme="dark"] {
     color-scheme: dark;
     --primary: #60a5fa;
@@ -2115,31 +2122,92 @@ html[data-theme="dark"] .badge-trusted { background: #3b0764; color: #c4b5fd; }
     text-decoration: underline;
 }
 
-/* Theme Toggle */
+/* Theme Toggle Switch */
 .theme-toggle {
     background: none;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
+    border: none;
     cursor: pointer;
-    padding: 0.4rem 0.6rem;
-    font-size: 1.1rem;
-    line-height: 1;
-    color: var(--text);
-    transition: background 0.2s, border-color 0.2s;
+    padding: 0;
     display: flex;
     align-items: center;
+    position: relative;
 }
 
-.theme-toggle:hover {
-    background: var(--bg-tertiary);
+.theme-switch {
+    width: 52px;
+    height: 28px;
+    border-radius: 14px;
+    background: #dbeafe;
+    border: 2px solid #bfdbfe;
+    position: relative;
+    transition: background 0.4s ease, border-color 0.4s ease;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 5px;
+}
+
+html[data-theme="dark"] .theme-switch {
+    background: #1e293b;
+    border-color: #334155;
+}
+
+.theme-switch-icon {
+    font-size: 0.8rem;
+    line-height: 1;
+    z-index: 1;
+    transition: opacity 0.3s ease;
+    user-select: none;
+}
+
+.theme-switch-icon-sun {
+    color: #f59e0b;
+    opacity: 1;
+}
+
+.theme-switch-icon-moon {
+    color: #94a3b8;
+    opacity: 0.5;
+}
+
+html[data-theme="dark"] .theme-switch-icon-sun {
+    opacity: 0.5;
+}
+
+html[data-theme="dark"] .theme-switch-icon-moon {
+    color: #e2e8f0;
+    opacity: 1;
+}
+
+.theme-switch-knob {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #ffffff;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), background 0.4s ease;
+}
+
+html[data-theme="dark"] .theme-switch-knob {
+    transform: translateX(24px);
+    background: #475569;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+
+.theme-toggle:hover .theme-switch {
     border-color: var(--primary);
 }
 
-.theme-toggle .theme-icon-light,
-.theme-toggle .theme-icon-dark { display: none; }
+.theme-toggle:active .theme-switch-knob {
+    width: 24px;
+}
 
-html:not([data-theme="dark"]) .theme-toggle .theme-icon-light { display: inline; }
-html[data-theme="dark"] .theme-toggle .theme-icon-dark { display: inline; }
+html[data-theme="dark"] .theme-toggle:active .theme-switch-knob {
+    transform: translateX(20px);
+}
 
 /* Racecar border hover — colored side races around the full border */
 .frontier-card:not(.frontier-completed),


### PR DESCRIPTION
## Summary
- Replace button-style night/day toggle with a pill-shaped **slide switch** (sun icon left, moon icon right, sliding knob)
- Page colors now **fade smoothly** on toggle (background, text, borders) instead of switching instantly
- Transition class (`theme-transitioning`) is added temporarily during toggle and removed after 600ms to avoid permanent performance cost
- Updated across all pages: main, for-machines, and moderation

## Test plan
- [ ] Click the toggle in light mode — knob slides right, page fades to dark
- [ ] Click the toggle in dark mode — knob slides left, page fades to light
- [ ] Verify sidebar toggle works the same as nav toggle
- [ ] Check for-machines and moderation pages have the new switch
- [ ] Verify theme persists across page reload (localStorage)
- [ ] Test on mobile — switch is tappable and visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)