### PR TITLE
Keep h2 underline at full width

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -304,14 +304,13 @@ section { margin-bottom: 4rem; }
     position: absolute;
     bottom: 0;
     left: 0;
-    width: 40%;
+    width: 100%;
     height: 3px;
     background: var(--primary);
-    transition: width 0.4s ease, background 0.4s ease;
+    transition: background 0.4s ease;
 }
 
 .section-header:hover::after {
-    width: 100%;
     background: var(--purple);
 }
 
@@ -396,14 +395,13 @@ h2::after {
     position: absolute;
     bottom: 0;
     left: 0;
-    width: 40%;
+    width: 100%;
     height: 3px;
     background: var(--primary);
-    transition: width 0.4s ease, background 0.4s ease;
+    transition: background 0.4s ease;
 }
 
 h2:hover::after {
-    width: 100%;
     background: var(--purple);
 }
 


### PR DESCRIPTION
## Summary
- Set header underline to 100% width by default instead of expanding from 40% on hover
- Retain the hover color transition from `--primary` to `--purple`
- Applied to both `.section-header::after` and `h2::after`

## Test plan
- [ ] Verify underline spans full width on page load
- [ ] Verify hover still transitions color to purple
- [ ] Verify other header animations (toggle arrow border-draw) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)