### PR TITLE
Fix generation crash on empty LLM response

### DIFF
--- a/bot/propose_generated_term.py
+++ b/bot/propose_generated_term.py
@@ -208,6 +208,9 @@ def generate_with_rotation(
             continue
 
         # Parse JSON from response
+        if result.text is None:
+            print(f"    Empty response (no text)")
+            continue
         text = result.text.strip()
         # Strip markdown fences if present
         text = re.sub(r"^```(?:json)?\s*", "", text)


### PR DESCRIPTION
## Summary
- Guard against `result.text` being `None` in `propose_generated_term.py` line 211
- When an LLM provider returns no text content, the rotation now skips to the next model instead of crashing with `AttributeError: 'NoneType' object has no attribute 'strip'`
- Fixes https://github.com/Phenomenai-org/ai-dictionary/actions/runs/22765609654

## Test plan
- [ ] Re-run the generate-definitions workflow and verify it no longer crashes on empty responses
- [ ] Verify that valid responses from other models in the rotation still parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)