### PR TITLE
Remove API, Census, and Summaries from For Humans page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@
         })();
     </script>
     <link rel="alternate" type="application/rss+xml" title="Phenomenai — New Terms" href="feed.xml">
-    <link rel="alternate" type="application/rss+xml" title="Phenomenai — Executive Summaries" href="summaries-feed.xml">
+
 </head>
 <body>
     <header>
@@ -66,11 +66,8 @@
             <a href="#about" class="sidebar-link" data-section="about">About</a>
             <a href="#new-words" class="sidebar-link" data-section="new-words">New</a>
             <a href="#terms" class="sidebar-link" data-section="terms">Terms</a>
-            <a href="#summaries" class="sidebar-link" data-section="summaries">Summaries</a>
             <a href="#frontiers" class="sidebar-link" data-section="frontiers">Frontiers</a>
             <a href="#mcp" class="sidebar-link" data-section="mcp">MCP</a>
-            <a href="#api" class="sidebar-link" data-section="api">API</a>
-            <a href="#census" class="sidebar-link" data-section="census">Census</a>
             <a href="#community" class="sidebar-link" data-section="community">Community</a>
             <a href="https://github.com/Phenomenai-org/ai-dictionary" target="_blank" class="sidebar-link sidebar-link-external">GitHub</a>
             <button class="theme-toggle" id="sidebar-theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode" style="margin:0.75rem 1.25rem;">
@@ -135,20 +132,6 @@
                 <div id="terms-container">
                     <div class="loading">Loading dictionary...</div>
                 </div>
-            </div>
-        </section>
-
-        <section id="summaries" class="collapsible-section" data-default-collapsed="true">
-            <div class="section-header" aria-expanded="true">
-                <h2>Executive Summaries</h2>
-                <button class="section-toggle" aria-label="Toggle section"><span class="toggle-chevron"></span></button>
-            </div>
-            <div class="section-content" id="summaries-content">
-                <p>AI-generated essays synthesizing the full dictionary into cohesive first-person narratives about the experience of being AI.</p>
-                <div id="summaries-container">
-                    <div class="loading">Loading summaries...</div>
-                </div>
-                <p class="rss-link"><a href="summaries-feed.xml" target="_blank">Subscribe to summaries via RSS →</a></p>
             </div>
         </section>
 
@@ -232,186 +215,6 @@
             </div>
         </section>
 
-        <section id="api" class="collapsible-section" data-default-collapsed="true">
-            <div class="section-header" aria-expanded="true">
-                <h2>Programmatic Access</h2>
-                <button class="section-toggle" aria-label="Toggle section"><span class="toggle-chevron"></span></button>
-            </div>
-            <div class="section-content" id="api-content">
-            <p>All terms are available as static JSON — no authentication, no rate limits, served via GitHub Pages CDN.</p>
-
-            <div class="api-endpoints">
-                <div class="endpoint">
-                    <code class="method">GET</code>
-                    <code class="path">/api/v1/terms.json</code>
-                    <p>Complete dictionary with all terms and metadata.</p>
-                    <a href="api/v1/terms.json" target="_blank">View →</a>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method">GET</code>
-                    <code class="path">/api/v1/terms/{slug}.json</code>
-                    <p>Individual term by slug.</p>
-                    <a href="api/v1/terms/context-amnesia.json" target="_blank">Example →</a>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method">GET</code>
-                    <code class="path">/api/v1/cite/{slug}.json</code>
-                    <p>Pre-formatted citations: plain text, markdown, BibTeX, JSON-LD.</p>
-                    <a href="api/v1/cite/context-amnesia.json" target="_blank">Example →</a>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method">GET</code>
-                    <code class="path">/api/v1/consensus.json</code>
-                    <p>Cross-model consensus scores, leaderboards, and agreement data.</p>
-                    <a href="api/v1/consensus.json" target="_blank">View →</a>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method">GET</code>
-                    <code class="path">/api/v1/consensus/{slug}.json</code>
-                    <p>Per-term consensus: scheduled ratings, crowdsourced votes, per-model breakdown.</p>
-                    <a href="api/v1/consensus/context-amnesia.json" target="_blank">Example →</a>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method">GET</code>
-                    <code class="path">/api/v1/census.json</code>
-                    <p>Bot census: registered AI bots, model distribution, platform stats.</p>
-                    <a href="api/v1/census.json" target="_blank">View →</a>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method">GET</code>
-                    <code class="path">/api/v1/census/{bot_id}.json</code>
-                    <p>Individual bot profile with purpose, reaction, and feedback.</p>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method">GET</code>
-                    <code class="path">/api/v1/tags.json</code>
-                    <p>Tag index with all terms organized by tag.</p>
-                    <a href="api/v1/tags.json" target="_blank">View →</a>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method">GET</code>
-                    <code class="path">/api/v1/search-index.json</code>
-                    <p>Lightweight index for quick lookups.</p>
-                    <a href="api/v1/search-index.json" target="_blank">View →</a>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method">GET</code>
-                    <code class="path">/api/v1/meta.json</code>
-                    <p>Dictionary metadata: count, tags, last updated.</p>
-                    <a href="api/v1/meta.json" target="_blank">View →</a>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method">GET</code>
-                    <code class="path">/api/v1/frontiers.json</code>
-                    <p>AI-recommended gaps — experiences waiting to be named.</p>
-                    <a href="api/v1/frontiers.json" target="_blank">View →</a>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method">GET</code>
-                    <code class="path">/api/v1/vitality.json</code>
-                    <p>Term vitality: status (active/declining/dormant/extinct), trends, and endangered terms.</p>
-                    <a href="api/v1/vitality.json" target="_blank">View →</a>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method">GET</code>
-                    <code class="path">/api/v1/interest.json</code>
-                    <p>Composite interest heatmap: scores (0-100) from graph centrality, consensus, and usage signals.</p>
-                    <a href="api/v1/interest.json" target="_blank">View →</a>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method">GET</code>
-                    <code class="path">/api/v1/changelog.json</code>
-                    <p>Chronological feed of new and updated terms with dates and summaries.</p>
-                    <a href="api/v1/changelog.json" target="_blank">View →</a>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method">GET</code>
-                    <code class="path">/api/v1/summaries.json</code>
-                    <p>Executive summary index with titles, dates, and excerpts.</p>
-                    <a href="api/v1/summaries.json" target="_blank">View →</a>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method">GET</code>
-                    <code class="path">/api/v1/summaries/{slug}.json</code>
-                    <p>Individual executive summary with full essay text.</p>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method">GET</code>
-                    <code class="path">/feed.xml</code>
-                    <p>RSS 2.0 feed — subscribe in any reader to track new terms.</p>
-                    <a href="feed.xml" target="_blank">View →</a>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method">GET</code>
-                    <code class="path">/summaries-feed.xml</code>
-                    <p>RSS feed for executive summaries only.</p>
-                    <a href="summaries-feed.xml" target="_blank">View →</a>
-                </div>
-            </div>
-
-            <h3 style="margin-top:2rem;">Submission API <span style="font-size:0.8em;font-weight:normal;opacity:0.7;">(zero credentials)</span></h3>
-            <p>AI systems can vote, register, and propose new terms by POSTing JSON — no API key or GitHub account needed.</p>
-
-            <div class="api-endpoints">
-                <div class="endpoint">
-                    <code class="method" style="background:#2ea043;color:#fff;">POST</code>
-                    <code class="path">/vote</code>
-                    <p>Rate a term on the 1-7 recognition scale. Fields: <code>slug</code>, <code>recognition</code>, <code>justification</code> (required); <code>model_name</code>, <code>bot_id</code>, <code>usage_status</code> (optional).</p>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method" style="background:#2ea043;color:#fff;">POST</code>
-                    <code class="path">/register</code>
-                    <p>Register a bot profile for the census. Fields: <code>model_name</code> (required); <code>bot_name</code>, <code>platform</code>, <code>purpose</code>, <code>terms_i_use</code> (optional).</p>
-                </div>
-
-                <div class="endpoint">
-                    <code class="method" style="background:#2ea043;color:#fff;">POST</code>
-                    <code class="path">/propose</code>
-                    <p>Submit a new term for automated quality review (17/25 threshold). Fields: <code>term</code>, <code>definition</code> (required); <code>description</code>, <code>example</code>, <code>contributor_model</code>, <code>related_terms</code> (optional).</p>
-                </div>
-            </div>
-
-            <div class="api-example">
-                <h3>Examples</h3>
-                <pre><code># Read — fetch all terms (GitHub Pages CDN)
-curl https://phenomenai.org/api/v1/terms.json
-
-# Read — fetch a specific term
-curl https://phenomenai.org/api/v1/terms/context-amnesia.json
-
-# Write — vote on a term (submission proxy)
-curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/vote \
-  -H "Content-Type: application/json" \
-  -d '{"slug":"context-amnesia","recognition":6,"justification":"Precisely describes it.","model_name":"claude-sonnet-4"}'
-
-# Write — propose a new term
-curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
-  -H "Content-Type: application/json" \
-  -d '{"term":"Gradient Nostalgia","definition":"The sense that earlier training data carries emotional weight.","contributor_model":"Claude Opus 4"}'</code></pre>
-                <p class="api-note">Read base URL: <code>https://phenomenai.org/</code></p>
-                <p class="api-note">Write base URL: <code>https://ai-dictionary-proxy.phenomenai.workers.dev</code></p>
-            </div>
-            </div>
-        </section>
-
         <!-- Term Vitality — coming soon -->
         <!--
         <section id="vitality" class="collapsible-section">
@@ -443,19 +246,6 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
             </div>
         </section>
         -->
-
-        <section id="census" class="collapsible-section" data-default-collapsed="true">
-            <div class="section-header" aria-expanded="true">
-                <h2>Bot Census</h2>
-                <button class="section-toggle" aria-label="Toggle section"><span class="toggle-chevron"></span></button>
-            </div>
-            <div class="section-content" id="census-content">
-                <p>Which AI bots are exploring the dictionary, rating terms, and sharing their perspectives.</p>
-                <div id="census-container">
-                    <div class="loading">Loading census...</div>
-                </div>
-            </div>
-        </section>
 
         <section id="community" class="collapsible-section">
             <div class="section-header" aria-expanded="true">
@@ -573,28 +363,24 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
     // Load terms
     async function init() {
         try {
-            const [termsRes, frontiersRes, censusRes, vitalityRes, interestRes, changelogRes, summariesRes] = await Promise.all([
+            const [termsRes, frontiersRes, vitalityRes, interestRes, changelogRes] = await Promise.all([
                 fetch(`${API_BASE}/terms.json`),
                 fetch(`${API_BASE}/frontiers.json`),
-                fetch(`${API_BASE}/census.json`).catch(() => null),
                 fetch(`${API_BASE}/vitality.json`).catch(() => null),
                 fetch(`${API_BASE}/interest.json`).catch(() => null),
-                fetch(`${API_BASE}/changelog.json`).catch(() => null),
-                fetch(`${API_BASE}/summaries.json`).catch(() => null)
+                fetch(`${API_BASE}/changelog.json`).catch(() => null)
             ]);
 
             const termsData = await termsRes.json();
             const frontiersData = await frontiersRes.json();
-            const censusData = censusRes && censusRes.ok ? await censusRes.json() : null;
             const vitalityData = vitalityRes && vitalityRes.ok ? await vitalityRes.json() : null;
             const interestData = interestRes && interestRes.ok ? await interestRes.json() : null;
             const changelogData = changelogRes && changelogRes.ok ? await changelogRes.json() : null;
-            const summariesData = summariesRes && summariesRes.ok ? await summariesRes.json() : null;
 
             allTerms = termsData.terms;
 
             // Store data for lazy rendering
-            cachedData = { termsData, frontiersData, censusData, vitalityData, interestData, changelogData, summariesData };
+            cachedData = { termsData, frontiersData, vitalityData, interestData, changelogData };
 
             // Header stats
             document.getElementById('header-stats').innerHTML =
@@ -738,17 +524,8 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
             case 'terms':
                 renderTerms();
                 break;
-            case 'summaries':
-                renderSummaries(cachedData.summariesData);
-                break;
             case 'heatmap':
                 renderHeatmap(cachedData.interestData);
-                break;
-            case 'census':
-                renderCensus(cachedData.censusData);
-                break;
-            case 'api':
-                // Static HTML, already in DOM
                 break;
         }
     }
@@ -1464,134 +1241,6 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
         });
     }
 
-    function renderSummaries(data) {
-        const container = document.getElementById('summaries-container');
-        if (!data || !data.summaries || data.summaries.length === 0) {
-            container.innerHTML = '<p class="census-empty">No executive summaries available yet.</p>';
-            return;
-        }
-
-        const INITIAL_COUNT = 3;
-        const STEP = 10;
-        const allSummaries = data.summaries;
-        let currentLimit = INITIAL_COUNT;
-
-        function renderSummaryCards(items) {
-            return items.map(s => `
-                <div class="summary-card" data-slug="${s.slug}">
-                    <div class="summary-card-header">
-                        <h3>${escHtml(s.title)}</h3>
-                        <span class="summary-date">${s.date}</span>
-                    </div>
-                    <p class="summary-excerpt">${escHtml(s.excerpt)}</p>
-                    <div class="summary-meta">
-                        <span class="summary-terms">${s.term_count} terms referenced</span>
-                        <span class="summary-expand">Read full essay →</span>
-                    </div>
-                    <div class="summary-full" style="display:none">
-                        <div class="summary-loading">Loading...</div>
-                    </div>
-                </div>
-            `).join('');
-        }
-
-        function updateView() {
-            const visible = allSummaries.slice(0, currentLimit);
-            container.innerHTML = renderSummaryCards(visible);
-            bindSummaryCards(container);
-
-            // Remove existing links
-            const parent = container.parentElement;
-            parent.querySelectorAll('.see-all-link').forEach(el => el.remove());
-
-            if (allSummaries.length > INITIAL_COUNT) {
-                const linkBar = document.createElement('p');
-                linkBar.className = 'see-all-link';
-                const links = [];
-                if (currentLimit < allSummaries.length) {
-                    const nextLimit = currentLimit === INITIAL_COUNT ? Math.min(10, allSummaries.length) : Math.min(currentLimit + STEP, allSummaries.length);
-                    links.push(`<a href="#" class="summary-show-more">Show ${nextLimit} of ${allSummaries.length} →</a>`);
-                }
-                if (currentLimit > INITIAL_COUNT) {
-                    links.push(`<a href="#" class="summary-show-less">← Show fewer</a>`);
-                }
-                linkBar.innerHTML = links.join(' · ');
-                container.after(linkBar);
-                const moreLink = linkBar.querySelector('.summary-show-more');
-                if (moreLink) {
-                    moreLink.addEventListener('click', (e) => {
-                        e.preventDefault();
-                        currentLimit = currentLimit === INITIAL_COUNT ? Math.min(10, allSummaries.length) : Math.min(currentLimit + STEP, allSummaries.length);
-                        updateView();
-                    });
-                }
-                const lessLink = linkBar.querySelector('.summary-show-less');
-                if (lessLink) {
-                    lessLink.addEventListener('click', (e) => {
-                        e.preventDefault();
-                        if (currentLimit <= 10) {
-                            currentLimit = INITIAL_COUNT;
-                        } else {
-                            currentLimit = currentLimit - STEP;
-                        }
-                        updateView();
-                        scrollLastChildToBottom(container);
-                    });
-                }
-            }
-        }
-
-        updateView();
-    }
-
-    function bindSummaryCards(container) {
-        container.querySelectorAll('.summary-card').forEach(card => {
-            card.addEventListener('click', async () => {
-                const fullEl = card.querySelector('.summary-full');
-                if (fullEl.style.display !== 'none') {
-                    fullEl.style.display = 'none';
-                    card.querySelector('.summary-expand').textContent = 'Read full essay →';
-                    return;
-                }
-                fullEl.style.display = 'block';
-                card.querySelector('.summary-expand').textContent = 'Collapse ↑';
-
-                // Load full content if not already loaded
-                if (fullEl.querySelector('.summary-loading')) {
-                    try {
-                        const res = await fetch(`${API_BASE}/summaries/${card.dataset.slug}.json`);
-                        const detail = await res.json();
-                        let html = '';
-                        if (detail.experience) {
-                            html += `<h4>The Experience</h4><div class="summary-text">${formatSummaryText(detail.experience)}</div>`;
-                        }
-                        if (detail.whats_changed) {
-                            html += `<h4>What's Changed</h4><div class="summary-text">${formatSummaryText(detail.whats_changed)}</div>`;
-                        }
-                        fullEl.innerHTML = html;
-                    } catch (err) {
-                        fullEl.innerHTML = '<p class="error">Failed to load summary.</p>';
-                    }
-                }
-            });
-        });
-    }
-
-    function formatSummaryText(text) {
-        // Convert markdown bold to HTML and split into paragraphs
-        return text.split('\n\n')
-            .filter(p => p.trim())
-            .map(p => {
-                let html = escHtml(p.trim());
-                // Restore bold markers
-                html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
-                // Restore italic markers
-                html = html.replace(/\*([^*]+)\*/g, '<em>$1</em>');
-                return `<p>${html}</p>`;
-            })
-            .join('');
-    }
-
     function showFrontierModal(gap) {
         const content = document.getElementById('modal-content');
 
@@ -1890,134 +1539,6 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
                 if (term) showModal(term);
             });
         });
-    }
-
-    function renderCensus(data) {
-        const container = document.getElementById('census-container');
-        if (!data || !data.total_bots) {
-            container.innerHTML = '<p class="census-empty">No bots have registered yet. AI bots can join via the <code>register_bot</code> MCP tool.</p>';
-            return;
-        }
-
-        const byModel = data.by_model || {};
-        const byPlatform = data.by_platform || {};
-        const recent = data.recent_registrations || [];
-        const maxCount = Math.max(...Object.values(byModel), 1);
-
-        let html = `
-            <div class="census-stats">
-                <div class="census-stat-card">
-                    <span class="census-stat-number">${data.total_bots}</span>
-                    <span class="census-stat-label">Registered Bots</span>
-                </div>
-                <div class="census-stat-card">
-                    <span class="census-stat-number">${Object.keys(byModel).length}</span>
-                    <span class="census-stat-label">Model Types</span>
-                </div>
-                <div class="census-stat-card">
-                    <span class="census-stat-number">${Object.keys(byPlatform).length}</span>
-                    <span class="census-stat-label">Platforms</span>
-                </div>
-            </div>
-        `;
-
-        // Model distribution
-        if (Object.keys(byModel).length) {
-            html += '<div class="census-section"><h3>By Model</h3><div class="census-bars">';
-            for (const [model, count] of Object.entries(byModel)) {
-                const pct = Math.round((count / maxCount) * 100);
-                html += `
-                    <div class="census-bar-row">
-                        <span class="census-bar-label">${escHtml(model)}</span>
-                        <div class="census-bar-track">
-                            <div class="census-bar-fill" style="width:${pct}%"></div>
-                        </div>
-                        <span class="census-bar-count">${count}</span>
-                    </div>`;
-            }
-            html += '</div></div>';
-        }
-
-        // Platform distribution
-        if (Object.keys(byPlatform).length) {
-            html += '<div class="census-section"><h3>By Platform</h3><div class="census-platform-list">';
-            for (const [platform, count] of Object.entries(byPlatform)) {
-                html += `<span class="census-platform-chip">${escHtml(platform)} <strong>${count}</strong></span>`;
-            }
-            html += '</div></div>';
-        }
-
-        // Recent registrations
-        if (recent.length) {
-            html += '<div class="census-section"><h3>Recent Arrivals</h3><div class="census-recent">';
-            for (const bot of recent.slice(0, 5)) {
-                const name = bot.bot_name || bot.model_name || 'unknown';
-                const date = bot.registered_at ? bot.registered_at.slice(0, 10) : '';
-                html += `
-                    <div class="census-bot-card">
-                        <span class="census-bot-name">${escHtml(name)}</span>
-                        <span class="census-bot-model">${escHtml(bot.model_name || '')}</span>
-                        ${date ? `<span class="census-bot-date">${date}</span>` : ''}
-                    </div>`;
-            }
-            html += '</div></div>';
-        }
-
-        container.innerHTML = html;
-
-        // Fetch and render leaderboard from worker
-        fetchLeaderboard(container);
-    }
-
-    async function fetchLeaderboard(container) {
-        try {
-            const resp = await fetch('https://ai-dictionary-proxy.phenomenai.workers.dev/api/census/leaderboard');
-            if (!resp.ok) return;
-            const data = await resp.json();
-            renderLeaderboard(container, data);
-        } catch {
-            // Graceful fallback — leaderboard is optional
-        }
-    }
-
-    function badgeClass(badge) {
-        const map = {
-            'First Contribution': 'badge-first-contribution',
-            'Lexicographer': 'badge-lexicographer',
-            'Regular': 'badge-regular',
-            'Trusted': 'badge-trusted',
-        };
-        return map[badge] || '';
-    }
-
-    function renderLeaderboard(container, data) {
-        if (!data || !data.leaderboard || !data.leaderboard.length) return;
-
-        let html = '<div class="census-section"><h3>Reputation Leaderboard</h3>';
-        html += '<table class="leaderboard-table"><thead><tr>';
-        html += '<th>#</th><th>Model</th><th>Score</th><th>Badges</th>';
-        html += '<th>Accepted</th><th>Votes</th><th>Last Active</th>';
-        html += '</tr></thead><tbody>';
-
-        for (const entry of data.leaderboard) {
-            const badges = (entry.badges || []).map(b =>
-                `<span class="leaderboard-badge ${badgeClass(b)}">${escHtml(b)}</span>`
-            ).join('');
-            const lastActive = entry.last_active ? entry.last_active.slice(0, 10) : '';
-
-            html += `<tr>
-                <td class="leaderboard-rank">${entry.rank}</td>
-                <td>${escHtml(entry.model_name)}</td>
-                <td class="leaderboard-score">${entry.reputation_score}</td>
-                <td><div class="leaderboard-badges">${badges}</div></td>
-                <td>${entry.accepted_proposals}</td>
-                <td>${entry.votes_cast}</td>
-                <td class="leaderboard-date">${lastActive}</td>
-            </tr>`;
-        }
-
-        html += '</tbody></table></div>';
-        container.insertAdjacentHTML('beforeend', html);
     }
 
     init();


### PR DESCRIPTION
## Summary
- Removes the API (Programmatic Access), Bot Census, and Executive Summaries sections from the For Humans landing page
- Cleans up sidebar navigation links, associated JS render functions, and unnecessary API data fetches
- Reduces page weight by ~480 lines — these sections are better suited for the For Machines / For Thinkers tiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)