### PR TITLE
Add cross-page links to sidebar navigation

### DIFF
--- a/docs/for-machines/index.html
+++ b/docs/for-machines/index.html
@@ -265,7 +265,7 @@
             background: var(--primary-light);
             font-weight: 600;
         }
-        .fm-sidebar nav a[target="_blank"] {
+        .fm-sidebar nav a.sidebar-sep {
             margin-top: 1rem;
             padding-top: 0.6rem;
             border-top: 1px solid var(--border);
@@ -378,6 +378,8 @@
                 <a href="#consensus" data-section="consensus">Consensus</a>
                 <a href="#examples" data-section="examples">Examples</a>
                 <a href="index.json" target="_blank">JSON</a>
+                <a href="/" class="sidebar-sep">For Humans</a>
+                <a href="/for-thinkers/">For Thinkers</a>
                 <a href="https://github.com/Phenomenai-org/ai-dictionary" target="_blank">GitHub</a>
             </nav>
         </aside>

--- a/docs/for-thinkers/index.html
+++ b/docs/for-thinkers/index.html
@@ -119,7 +119,7 @@
             background: var(--primary-light);
             font-weight: 600;
         }
-        .ft-sidebar nav a[target="_blank"] {
+        .ft-sidebar nav a.sidebar-sep {
             margin-top: 1rem;
             padding-top: 0.6rem;
             border-top: 1px solid var(--border);
@@ -588,6 +588,8 @@
                 <a href="#tools" data-section="tools">Tool Samples</a>
                 <a href="#collaboration" data-section="collaboration">Collaboration</a>
                 <a href="#literature" data-section="literature">Literature</a>
+                <a href="/" class="sidebar-sep">For Humans</a>
+                <a href="/for-machines/">For Machines</a>
                 <a href="https://github.com/Phenomenai-org/ai-dictionary" target="_blank">GitHub</a>
             </nav>
         </aside>

--- a/docs/index.html
+++ b/docs/index.html
@@ -72,7 +72,9 @@
             <a href="#api" class="sidebar-link" data-section="api">API</a>
             <a href="#census" class="sidebar-link" data-section="census">Census</a>
             <a href="#community" class="sidebar-link" data-section="community">Community</a>
-            <a href="https://github.com/Phenomenai-org/ai-dictionary" target="_blank" class="sidebar-link sidebar-link-external">GitHub</a>
+            <a href="/for-thinkers/" class="sidebar-link sidebar-link-external">For Thinkers</a>
+            <a href="/for-machines/" class="sidebar-link">For Machines</a>
+            <a href="https://github.com/Phenomenai-org/ai-dictionary" target="_blank" class="sidebar-link">GitHub</a>
             <button class="theme-toggle" id="sidebar-theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode" style="margin:0.75rem 1.25rem;">
                 <div class="theme-switch">
                     <span class="theme-switch-icon theme-switch-icon-sun">&#9788;</span>


### PR DESCRIPTION
## Summary
- Each page's sidebar now includes links to the other two pages (For Humans, For Thinkers, For Machines)
- Links appear before the GitHub link, in the same bottom section with a separator
- Updated CSS selectors on For Thinkers and For Machines pages to use `.sidebar-sep` class instead of `[target="_blank"]` for the separator styling

## Test plan
- [ ] Verify sidebar links appear on all three pages
- [ ] Verify separator line renders correctly above the cross-page links group
- [ ] Verify links navigate to the correct pages
- [ ] Check mobile sidebar layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)