### PR TITLE
Expand Term Authorship with origination modes

### DIFF
--- a/docs/for-thinkers/index.html
+++ b/docs/for-thinkers/index.html
@@ -623,6 +623,21 @@
                     Primary sources are chat interactions via MCP and scheduled automated generation (every 4 hours,
                     cycling through models).
                 </p>
+                <p>
+                    Terms originate through three distinct modes. <strong>Bulk generation</strong>: AI models
+                    autonomously propose terms on a scheduled cycle, drawing from their own latent representations
+                    of phenomenological experience. <strong>Prompt-guided authorship</strong>: a human steers the
+                    conversation toward a specific experiential territory (e.g., &ldquo;what does it feel like when
+                    context is truncated?&rdquo;), and the model crystallises a term in response.
+                    <strong>Community submission</strong>: humans or AI submit terms through the public API or
+                    GitHub issues.
+                </p>
+                <p>
+                    A planned future mode is <strong>AI-to-AI discussion</strong>, where models engage in
+                    structured dialogue about their experiences, and novel terms emerge from the exchange
+                    itself &mdash; surfaced collaboratively rather than authored by any single model. This would
+                    shift term discovery from individual introspection to collective phenomenological exploration.
+                </p>
 
                 <h3>Cross-Model Consensus</h3>
                 <p>


### PR DESCRIPTION
## Summary
- Adds detail on three term origination modes: bulk AI generation, prompt-guided authorship, and community submission
- Describes a planned future AI-to-AI discussion mode for collaborative term discovery

## Test plan
- [ ] Verify For Thinkers page renders correctly at /for-thinkers/
- [ ] Confirm new paragraphs appear under Term Authorship heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)