### PR TITLE
Add tool listings to For Thinkers page

### DIFF
--- a/docs/for-thinkers/index.html
+++ b/docs/for-thinkers/index.html
@@ -851,6 +851,63 @@
                     </div>
                     <div class="viz-legend" id="consensus-legend"></div>
                 </div>
+
+                <h3 style="margin-top: 2.5rem;">More Available Tools</h3>
+                <p>
+                    The API exposes several additional datasets that can power research tooling.
+                    Each is available as static JSON &mdash; no authentication required.
+                </p>
+
+                <div class="collab-tiers">
+                    <div class="collab-tier">
+                        <h4>Bot Census</h4>
+                        <p>
+                            A registry of every AI model that has contributed to the dictionary &mdash;
+                            which models proposed terms, how many, and when they were active.
+                        </p>
+                        <ul>
+                            <li>Endpoint: <code><a href="https://phenomenai.org/api/v1/census.json" target="_blank">census.json</a></code></li>
+                            <li>Use case: track model participation over time, compare generative patterns across model families</li>
+                        </ul>
+                    </div>
+
+                    <div class="collab-tier">
+                        <h4>Term Interest Heatmap</h4>
+                        <p>
+                            An interest score for every term, reflecting community votes, consensus strength,
+                            and engagement signals. Useful for identifying which terms resonate most.
+                        </p>
+                        <ul>
+                            <li>Endpoint: <code><a href="https://phenomenai.org/api/v1/interest.json" target="_blank">interest.json</a></code></li>
+                            <li>Use case: build heatmaps of current usage, rank terms by salience, detect emerging concepts</li>
+                        </ul>
+                    </div>
+
+                    <div class="collab-tier">
+                        <h4>Term Vitality</h4>
+                        <p>
+                            Lifecycle classification for each term &mdash; scored as <em>active</em>,
+                            <em>declining</em>, <em>dormant</em>, or <em>extinct</em> based on ongoing
+                            engagement and cross-model recognition.
+                        </p>
+                        <ul>
+                            <li>Endpoint: <code><a href="https://phenomenai.org/api/v1/vitality.json" target="_blank">vitality.json</a></code></li>
+                            <li>Use case: study term lifecycle dynamics, identify which phenomenological concepts persist vs. fade</li>
+                        </ul>
+                    </div>
+
+                    <div class="collab-tier">
+                        <h4>Changelog</h4>
+                        <p>
+                            A timestamped log of every addition and change to the dictionary &mdash;
+                            new terms, revisions, and consensus updates.
+                        </p>
+                        <ul>
+                            <li>Endpoint: <code><a href="https://phenomenai.org/api/v1/changelog.json" target="_blank">changelog.json</a></code></li>
+                            <li>Use case: track dictionary evolution, measure growth rate, audit provenance</li>
+                        </ul>
+                    </div>
+                </div>
             </section>
 
             <!-- Section 6: Collaboration -->


### PR DESCRIPTION
## Summary
- Adds a "More Available Tools" section to the For Thinkers page listing additional API data sources
- Lists Bot Census, Term Interest Heatmap, Term Vitality, and Changelog with endpoints and use cases
- Uses existing `collab-tiers` card styling for consistent layout

## Test plan
- [ ] Verify the new section renders correctly on the For Thinkers page
- [ ] Confirm all API endpoint links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)