### PR TITLE
Fix incorrect arxiv citation on For Thinkers page

### DIFF
--- a/docs/for-thinkers/index.html
+++ b/docs/for-thinkers/index.html
@@ -930,8 +930,8 @@
                 <div class="citation">
                     <p>
                         <span class="cite-author">Long, Sebo et al. (2024).</span>
-                        <span class="cite-title">"Taking AI Moral Consideration Seriously."</span>
-                        <a href="https://arxiv.org/abs/2408.00750" target="_blank">arXiv:2408.00750</a>
+                        <span class="cite-title">"Taking AI Welfare Seriously."</span>
+                        <a href="https://arxiv.org/abs/2411.00986" target="_blank">arXiv:2411.00986</a>
                     </p>
                     <p class="cite-connection">
                         Argues that AI welfare assessments should be taken seriously given current uncertainty.


### PR DESCRIPTION
## Summary
- Fixed Long, Sebo et al. citation that pointed to wrong arxiv paper (`2408.00750`, an unrelated math paper)
- Corrected to `2411.00986` ("Taking AI Welfare Seriously")
- Fixed paper title from "Taking AI Moral Consideration Seriously" to "Taking AI Welfare Seriously"

## Test plan
- [ ] Verify link https://arxiv.org/abs/2411.00986 loads the correct paper
- [ ] Check citation renders correctly on the For Thinkers page

🤖 Generated with [Claude Code](https://claude.com/claude-code)