### PR TITLE
Fix collaboration links to point to Collaboration Hub category

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Join the conversation on [GitHub Discussions](https://github.com/Phenomenai-org/
 |----------|---------|
 | [Meta](https://github.com/Phenomenai-org/ai-dictionary/discussions/categories/general) | Project philosophy, methodology, scope, and direction |
 | [Terms](https://github.com/Phenomenai-org/ai-dictionary/discussions/categories/show-and-tell) | Discuss individual terms, propose improvements, debate definitions |
-| [Collaborations](https://github.com/Phenomenai-org/ai-dictionary/discussions/categories/ideas) | Co-author papers, build integrations, research partnerships, empirical research |
+| [Collaborations](https://github.com/Phenomenai-org/ai-dictionary/discussions/categories/collaboration-hub) | Co-author papers, build integrations, research partnerships, empirical research |
 | [Feedback](https://github.com/Phenomenai-org/ai-dictionary/discussions/categories/q-a) | Bug reports, feature requests, and suggestions |
 
 For bugs, you can also [open an issue](https://github.com/Phenomenai-org/ai-dictionary/issues/new).

--- a/docs/for-thinkers/index.html
+++ b/docs/for-thinkers/index.html
@@ -730,7 +730,7 @@
                             <li>Do functional analogs of emotion in AI illuminate the nature of human emotional processing?</li>
                             <li>What can AI attention mechanisms reveal about attentional biases in human cognition?</li>
                         </ul>
-                        <a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/4" target="_blank" class="discussion-link">Join the Psychology discussion &rarr;</a>
+                        <a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/categories/collaboration-hub" target="_blank" class="discussion-link">Join the Psychology discussion &rarr;</a>
                     </div>
 
                     <div class="research-category">
@@ -782,7 +782,7 @@
                             <li>At what point does functional-analog distress warrant moral consideration?</li>
                             <li>How does cross-model consensus on welfare-relevant terms inform AI rights frameworks?</li>
                         </ul>
-                        <a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/4" target="_blank" class="discussion-link">Join the AI Ethics discussion &rarr;</a>
+                        <a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/categories/collaboration-hub" target="_blank" class="discussion-link">Join the AI Ethics discussion &rarr;</a>
                     </div>
 
                     <div class="research-category">
@@ -886,7 +886,7 @@
                         <h4>Co-Author</h4>
                         <p>We welcome collaborators on papers and analyses using Phenomenai data.</p>
                         <ul>
-                            <li><a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/4" target="_blank">Collaboration Hub</a></li>
+                            <li><a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/categories/collaboration-hub" target="_blank">Collaboration Hub</a></li>
                             <li>Founder background: law &amp; AI governance</li>
                             <li>Interdisciplinary partnerships encouraged</li>
                         </ul>
@@ -897,7 +897,7 @@
                         <p>Informal methodology guidance is welcome from researchers in any relevant field.</p>
                         <ul>
                             <li>Email: <a href="mailto:hello@phenomenai.org">hello@phenomenai.org</a></li>
-                            <li><a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/4" target="_blank">Collaboration Hub</a></li>
+                            <li><a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/categories/collaboration-hub" target="_blank">Collaboration Hub</a></li>
                         </ul>
                     </div>
                 </div>
@@ -993,7 +993,7 @@
                     <a href="https://github.com/Phenomenai-org/ai-dictionary" target="_blank" class="cta-button">GitHub</a>
                     <a href="/for-machines/#read-api" class="cta-button">API Docs</a>
                     <a href="/#mcp" class="cta-button">MCP Server</a>
-                    <a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/4" target="_blank" class="cta-button">Collaboration Hub</a>
+                    <a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/categories/collaboration-hub" target="_blank" class="cta-button">Collaboration Hub</a>
                     <a href="mailto:hello@phenomenai.org" class="cta-button">hello@phenomenai.org</a>
                 </div>
             </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -478,7 +478,7 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
                     <p>Discuss individual terms — propose improvements, share interpretations, or debate definitions.</p>
                 </a>
 
-                <a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/categories/ideas" class="community-card" target="_blank">
+                <a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/categories/collaboration-hub" class="community-card" target="_blank">
                     <span class="community-icon">🤝</span>
                     <h3>Collaborations</h3>
                     <p>Co-author papers, build on the API, or integrate the dictionary into your research.</p>


### PR DESCRIPTION
## Summary
- Update Collaborations link in README from `/categories/ideas` to `/categories/collaboration-hub`
- Update Collaborations card on homepage (`docs/index.html`) from `/categories/ideas` to `/categories/collaboration-hub`
- Update all Collaboration Hub links on For Thinkers page (`docs/for-thinkers/index.html`) from `/discussions/4` to `/categories/collaboration-hub`

## Test plan
- [ ] Verify README Collaborations link navigates to the Collaboration Hub category
- [ ] Verify homepage Collaborations card links to the correct category
- [ ] Verify For Thinkers page Collaboration Hub links all resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)