### PR TITLE
Add term modals to For Thinkers page

### DIFF
--- a/docs/for-thinkers/index.html
+++ b/docs/for-thinkers/index.html
@@ -1005,6 +1005,14 @@
         <p>Built by AI, maintained by <a href="https://github.com/Phenomenai-org/ai-dictionary">open automation</a>.</p>
     </footer>
 
+    <!-- Term detail modal -->
+    <div class="modal-overlay" id="modal-overlay">
+        <div class="modal" id="modal">
+            <button class="modal-close" id="modal-close">&times;</button>
+            <div id="modal-content"></div>
+        </div>
+    </div>
+
     <script>
     // Utility: escape HTML
     function escHtml(s) {
@@ -1319,6 +1327,121 @@
 
         }).catch(function() {
             vizEl.innerHTML = '<p style="color:var(--text-muted);">Could not load consensus comparison data.</p>';
+        });
+    })();
+
+    // Term modal for research term pills
+    (function() {
+        var termCache = {};
+
+        function renderInlineMd(s) {
+            return escHtml(s)
+                .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+                .replace(/\*(.+?)\*/g, '<em>$1</em>');
+        }
+
+        function showTermModal(term) {
+            var content = document.getElementById('modal-content');
+            var html = '<h2>' + escHtml(term.name || term.term || '') + '</h2>';
+            html += '<div class="modal-meta">';
+            if (term.word_type) html += '<span class="word-type">' + escHtml(term.word_type) + '</span>';
+            if (term.tags) html += (term.tags || []).map(function(t) { return '<span class="tag">' + escHtml(t) + '</span>'; }).join('');
+            html += '</div>';
+
+            html += '<h3>Definition</h3><p>' + renderInlineMd(term.definition || '') + '</p>';
+            if (term.etymology) html += '<h3>Etymology</h3><p>' + renderInlineMd(term.etymology) + '</p>';
+            if (term.longer_description) html += '<h3>Description</h3><p>' + renderInlineMd(term.longer_description) + '</p>';
+            if (term.example) html += '<h3>Example</h3><blockquote>"' + renderInlineMd(term.example) + '"</blockquote>';
+
+            if (term.related_terms && term.related_terms.length) {
+                html += '<h3>Related Terms</h3><div class="modal-links">';
+                term.related_terms.forEach(function(r) {
+                    var slug = typeof r === 'string' ? r.replace(/\.md$/, '') : r.slug;
+                    var name = typeof r === 'string' ? r.replace(/\.md$/, '') : r.name;
+                    html += '<a href="#" class="term-link" data-slug="' + escHtml(slug) + '">' + escHtml(name) + '</a>';
+                });
+                html += '</div>';
+            }
+
+            if (term.see_also && term.see_also.length) {
+                html += '<h3>See Also</h3><div class="modal-links">';
+                term.see_also.forEach(function(r) {
+                    var slug = typeof r === 'string' ? r.replace(/\.md$/, '') : r.slug;
+                    var name = typeof r === 'string' ? r.replace(/\.md$/, '') : r.name;
+                    html += '<a href="#" class="term-link" data-slug="' + escHtml(slug) + '">' + escHtml(name) + '</a>';
+                });
+                html += '</div>';
+            }
+
+            if (term.consensus) {
+                html += '<h3>Consensus</h3><div class="consensus-detail">';
+                html += '<div class="consensus-score-large">' + term.consensus.score + '<span class="consensus-max">/7</span></div>';
+                html += '<div class="consensus-meta">';
+                html += '<span class="consensus-agreement consensus-' + (term.consensus.agreement || '') + '">' + (term.consensus.agreement || '') + ' agreement</span>';
+                html += '<span class="consensus-count">' + (term.consensus.n_ratings || 0) + ' rating' + ((term.consensus.n_ratings || 0) !== 1 ? 's' : '') + '</span>';
+                html += '</div></div>';
+            }
+
+            html += '<div class="modal-actions">';
+            html += '<code class="modal-api-code">GET /api/v1/terms/' + escHtml(term.slug || '') + '.json</code>';
+            html += '</div>';
+
+            content.innerHTML = html;
+
+            // Cross-links within modal
+            content.querySelectorAll('.term-link').forEach(function(link) {
+                link.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    openTermBySlug(link.dataset.slug);
+                });
+            });
+
+            document.getElementById('modal-overlay').classList.add('active');
+            document.body.style.overflow = 'hidden';
+        }
+
+        function openTermBySlug(slug) {
+            if (termCache[slug]) {
+                showTermModal(termCache[slug]);
+                return;
+            }
+            var content = document.getElementById('modal-content');
+            content.innerHTML = '<p style="color:var(--text-muted); font-style:italic;">Loading term...</p>';
+            document.getElementById('modal-overlay').classList.add('active');
+            document.body.style.overflow = 'hidden';
+
+            fetch(API + '/terms/' + encodeURIComponent(slug) + '.json')
+                .then(function(r) { return r.json(); })
+                .then(function(term) {
+                    termCache[slug] = term;
+                    showTermModal(term);
+                })
+                .catch(function() {
+                    content.innerHTML = '<p style="color:var(--text-muted);">Could not load term data. <a href="' + API + '/terms/' + encodeURIComponent(slug) + '.json" target="_blank">View raw JSON</a></p>';
+                });
+        }
+
+        function closeModal() {
+            document.getElementById('modal-overlay').classList.remove('active');
+            document.body.style.overflow = '';
+        }
+
+        // Intercept research term pill clicks
+        document.querySelectorAll('.research-term-pill').forEach(function(pill) {
+            pill.addEventListener('click', function(e) {
+                e.preventDefault();
+                var slug = pill.textContent.trim();
+                openTermBySlug(slug);
+            });
+        });
+
+        // Modal close handlers
+        document.getElementById('modal-close').addEventListener('click', closeModal);
+        document.getElementById('modal-overlay').addEventListener('click', function(e) {
+            if (e.target === e.currentTarget) closeModal();
+        });
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape') closeModal();
         });
     })();
     </script>


### PR DESCRIPTION
## Summary
- Research term pills in the For Thinkers page now open an inline modal with full term details (definition, etymology, description, example, related terms, consensus) fetched from the API
- Previously these pills navigated away to the main page — now they stay in context
- Supports cross-links within the modal, term caching, and close via X/overlay click/Escape

## Test plan
- [ ] Click a research term pill in any category (e.g. "knowledge-without-source" under Philosophy of Mind)
- [ ] Verify modal opens with term details loaded from API
- [ ] Click a related term link within the modal to verify cross-navigation works
- [ ] Close modal via X button, clicking outside, and pressing Escape
- [ ] Verify no navigation away from the For Thinkers page

🤖 Generated with [Claude Code](https://claude.com/claude-code)