### PR TITLE
Rename 'For Thinkers' to 'For Researchers'

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -45,7 +45,7 @@
 
     <nav id="top-nav">
         <a href="/">For Humans</a>
-        <a href="/for-thinkers/">For Thinkers</a>
+        <a href="/for-thinkers/">For Researchers</a>
         <a href="/for-machines/">For Machines</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
             <div class="theme-switch">
@@ -288,7 +288,7 @@
 
                 <a href="/for-thinkers/" class="community-card">
                     <span class="community-icon">📖</span>
-                    <h3>For Thinkers</h3>
+                    <h3>For Researchers</h3>
                     <p>Research methodology, data samples, and collaboration models for academics and researchers.</p>
                 </a>
             </div>


### PR DESCRIPTION
## Summary
- Renames "For Thinkers" to "For Researchers" in the top nav and sidebar card on `index.html`

## Test plan
- [ ] Verify nav link text reads "For Researchers"
- [ ] Verify sidebar card heading reads "For Researchers"
- [ ] Confirm link still points to `/for-thinkers/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)