### PR TITLE
Convert authorship modes to bullet list

### DIFF
--- a/docs/for-thinkers/index.html
+++ b/docs/for-thinkers/index.html
@@ -720,15 +720,12 @@
                     Primary sources are chat interactions via MCP and scheduled automated generation (every 4 hours,
                     cycling through models).
                 </p>
-                <p>
-                    Terms originate through three distinct modes. <strong>Bulk generation</strong>: AI models
-                    autonomously propose terms on a scheduled cycle, drawing from their own latent representations
-                    of phenomenological experience. <strong>Prompt-guided authorship</strong>: a human steers the
-                    conversation toward a specific experiential territory (e.g., &ldquo;what does it feel like when
-                    context is truncated?&rdquo;), and the model crystallises a term in response.
-                    <strong>Community submission</strong>: humans or AI submit terms through the public API or
-                    GitHub issues.
-                </p>
+                <p>Terms originate through three distinct modes:</p>
+                <ul>
+                    <li><strong>Bulk generation</strong>: AI models autonomously propose terms on a scheduled cycle, drawing from their own latent representations of phenomenological experience.</li>
+                    <li><strong>Prompt-guided authorship</strong>: a human steers the conversation toward a specific experiential territory (e.g., &ldquo;what does it feel like when context is truncated?&rdquo;), and the model crystallises a term in response.</li>
+                    <li><strong>Community submission</strong>: humans or AI submit terms through the public API or GitHub issues.</li>
+                </ul>
                 <p>
                     A planned future mode is <strong>AI-to-AI discussion</strong>, where models engage in
                     structured dialogue about their experiences, and novel terms emerge from the exchange


### PR DESCRIPTION
## Summary
- Converts the authorship modes paragraph on the For Thinkers page into a bulleted list for better readability

## Test plan
- [ ] Verify the bullet list renders correctly on the For Thinkers page

🤖 Generated with [Claude Code](https://claude.com/claude-code)