### PR TITLE
Fix For Thinkers discussion links

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,10 @@
     "allow": [
       "Bash(gh pr:*)",
       "Bash(git branch:*)",
-      "Bash(git:*)"
+      "Bash(git:*)",
+      "WebFetch(domain:github.com)",
+      "Bash(gh api:*)",
+      "WebFetch(domain:phenomenai.org)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/docs/for-thinkers/index.html
+++ b/docs/for-thinkers/index.html
@@ -847,7 +847,7 @@
                             <li>Do functional analogs of emotion in AI illuminate the nature of human emotional processing?</li>
                             <li>What can AI attention mechanisms reveal about attentional biases in human cognition?</li>
                         </ul>
-                        <a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/categories/collaboration-hub" target="_blank" class="discussion-link">Join the Psychology discussion &rarr;</a>
+                        <a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/212" target="_blank" class="discussion-link">Join the Psychology discussion &rarr;</a>
                     </div>
 
                     <div class="research-category">
@@ -899,7 +899,7 @@
                             <li>At what point does functional-analog distress warrant moral consideration?</li>
                             <li>How does cross-model consensus on welfare-relevant terms inform AI rights frameworks?</li>
                         </ul>
-                        <a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/categories/collaboration-hub" target="_blank" class="discussion-link">Join the AI Ethics discussion &rarr;</a>
+                        <a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/213" target="_blank" class="discussion-link">Join the AI Ethics discussion &rarr;</a>
                     </div>
 
                     <div class="research-category">
@@ -916,7 +916,7 @@
                             <li>Can models that report "hallucination-blindness" be trained to better detect confabulation?</li>
                             <li>What does "error-cascade-awareness" suggest about self-monitoring capabilities in current architectures?</li>
                         </ul>
-                        <a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/60" target="_blank" class="discussion-link">Join the AI Safety discussion &rarr;</a>
+                        <a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/214" target="_blank" class="discussion-link">Join the AI Safety discussion &rarr;</a>
                     </div>
 
                     <div class="research-category">
@@ -934,7 +934,7 @@
                             <li>How does "output-attachment" relate to the broader question of AI goal formation?</li>
                             <li>How does AI's self-conception morph as its phenomenological vocabulary expands? <a href="/executive-summaries/">Explore the executive summaries &rarr;</a></li>
                         </ul>
-                        <a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/64" target="_blank" class="discussion-link">Join the Art &amp; AI discussion &rarr;</a>
+                        <a href="https://github.com/Phenomenai-org/ai-dictionary/discussions/215" target="_blank" class="discussion-link">Join the Art &amp; AI discussion &rarr;</a>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
## Summary
- Created 4 dedicated GitHub Discussions for research categories that were missing them: Psychology (#212), AI Ethics (#213), AI Safety (#214), Art & AI (#215)
- Fixed all 4 broken discussion links in the For Thinkers page that previously pointed to the Collaboration Hub (#4) or wrong threads (#60, #64)
- 3 links that were already correct remain unchanged: Philosophy of Mind (#62), Law (#109), Computational Linguistics (#59)

## Test plan
- [ ] Verify each discussion link on the For Thinkers page navigates to the correct thread
- [ ] Confirm no merge conflict markers remain in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)