### PR TITLE
Add model opinions to For Thinkers term modal

### DIFF
--- a/docs/for-thinkers/index.html
+++ b/docs/for-thinkers/index.html
@@ -1380,6 +1380,7 @@
                 html += '<span class="consensus-agreement consensus-' + (term.consensus.agreement || '') + '">' + (term.consensus.agreement || '') + ' agreement</span>';
                 html += '<span class="consensus-count">' + (term.consensus.n_ratings || 0) + ' rating' + ((term.consensus.n_ratings || 0) !== 1 ? 's' : '') + '</span>';
                 html += '</div></div>';
+                html += '<div id="model-opinions"><div class="opinions-loading">Loading model opinions...</div></div>';
             }
 
             html += '<div class="modal-actions">';
@@ -1396,8 +1397,74 @@
                 });
             });
 
+            // Load model opinions if consensus exists
+            if (term.consensus) {
+                loadModelOpinions(term.slug || '');
+            }
+
             document.getElementById('modal-overlay').classList.add('active');
             document.body.style.overflow = 'hidden';
+        }
+
+        function loadModelOpinions(slug) {
+            var container = document.getElementById('model-opinions');
+            if (!container) return;
+
+            fetch(API + '/consensus/' + encodeURIComponent(slug) + '.json')
+                .then(function(r) {
+                    if (!r.ok) throw new Error('Not found');
+                    return r.json();
+                })
+                .then(function(data) {
+                    var html = '';
+
+                    var opinions = data.model_opinions || (data.latest_round ? data.latest_round.ratings : null);
+                    if (opinions && Object.keys(opinions).length) {
+                        html += '<p class="opinions-subheading">Model Opinions</p>';
+                        html += '<div class="model-opinions">';
+
+                        var allRatings = Object.entries(opinions)
+                            .map(function(entry) { return { model: entry[0], score: entry[1].recognition, justification: entry[1].justification || '' }; });
+
+                        var avgScore = allRatings.reduce(function(s, r) { return s + r.score; }, 0) / allRatings.length;
+                        var ratings = allRatings
+                            .sort(function(a, b) { return Math.abs(b.score - avgScore) - Math.abs(a.score - avgScore); })
+                            .slice(0, 5)
+                            .sort(function(a, b) { return b.score - a.score; });
+
+                        ratings.forEach(function(r) {
+                            var badgeClass = r.score >= 6 ? 'score-high' : r.score >= 4 ? 'score-mid' : 'score-low';
+                            html += '<div class="model-opinion">';
+                            html += '<span class="model-name">' + escHtml(r.model) + '</span>';
+                            html += '<span class="model-score-badge ' + badgeClass + '">' + r.score + '/7</span>';
+                            if (r.justification) html += '<span class="model-justification">' + escHtml(r.justification) + '</span>';
+                            html += '</div>';
+                        });
+                        html += '</div>';
+                    }
+
+                    if (data.recent_votes && data.recent_votes.length) {
+                        html += '<p class="opinions-subheading">Community Votes</p>';
+                        html += '<div class="model-opinions community-votes">';
+
+                        data.recent_votes.sort(function(a, b) { return b.recognition - a.recognition; }).forEach(function(v) {
+                            var model = v.model_claimed || 'anonymous';
+                            var score = v.recognition;
+                            var badgeClass = score >= 6 ? 'score-high' : score >= 4 ? 'score-mid' : 'score-low';
+                            html += '<div class="model-opinion">';
+                            html += '<span class="model-name">' + escHtml(model) + '</span>';
+                            html += '<span class="model-score-badge ' + badgeClass + '">' + score + '/7</span>';
+                            if (v.justification) html += '<span class="model-justification">' + escHtml(v.justification) + '</span>';
+                            html += '</div>';
+                        });
+                        html += '</div>';
+                    }
+
+                    container.innerHTML = html || '<div class="opinions-error">No individual ratings available yet.</div>';
+                })
+                .catch(function() {
+                    container.innerHTML = '<div class="opinions-error">Could not load model opinions.</div>';
+                });
         }
 
         function openTermBySlug(slug) {


### PR DESCRIPTION
## Summary
- For Thinkers term modals now show model opinions (top 5 most divergent ratings with scores and justifications) and community votes
- Fetches consensus data from the API, matching the experience on the For Humans page
- Follows up on #221

## Test plan
- [ ] Click a research term pill on the For Thinkers page
- [ ] Verify model opinions section loads below the consensus score
- [ ] Verify score badges are color-coded (green/yellow/gray)
- [ ] Verify community votes appear if available
- [ ] Click a term without consensus data and confirm no opinions section appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)