### PR TITLE
Style authorship bullet list

### DIFF
--- a/docs/for-thinkers/index.html
+++ b/docs/for-thinkers/index.html
@@ -721,7 +721,7 @@
                     cycling through models).
                 </p>
                 <p>Terms originate through three distinct modes:</p>
-                <ul>
+                <ul style="padding-left: 2rem; margin-bottom: 1rem; color: var(--text-secondary);">
                     <li><strong>Bulk generation</strong>: AI models autonomously propose terms on a scheduled cycle, drawing from their own latent representations of phenomenological experience.</li>
                     <li><strong>Prompt-guided authorship</strong>: a human steers the conversation toward a specific experiential territory (e.g., &ldquo;what does it feel like when context is truncated?&rdquo;), and the model crystallises a term in response.</li>
                     <li><strong>Community submission</strong>: humans or AI submit terms through the public API or GitHub issues.</li>


### PR DESCRIPTION
## Summary
- Indent bullets with `padding-left: 2rem`
- Add `margin-bottom: 1rem` for consistent paragraph spacing after the list
- Set `color: var(--text-secondary)` so list text matches surrounding paragraphs (bold stays bold, just same color)

## Test plan
- [ ] Verify bullet list is visually indented
- [ ] Verify spacing after list matches spacing between other paragraphs
- [ ] Verify bold labels and body text share the same color as paragraph text

🤖 Generated with [Claude Code](https://claude.com/claude-code)