### PR TITLE
Add cite/consensus/attribution to For Thinkers modal, remove interest from For Humans

### DIFF
--- a/docs/for-thinkers/index.html
+++ b/docs/for-thinkers/index.html
@@ -1379,12 +1379,21 @@
                 html += '<div class="consensus-meta">';
                 html += '<span class="consensus-agreement consensus-' + (term.consensus.agreement || '') + '">' + (term.consensus.agreement || '') + ' agreement</span>';
                 html += '<span class="consensus-count">' + (term.consensus.n_ratings || 0) + ' rating' + ((term.consensus.n_ratings || 0) !== 1 ? 's' : '') + '</span>';
-                html += '</div></div>';
+                html += '</div>';
+                html += '<a href="' + API + '/consensus/' + escAttr(term.slug || '') + '.json" target="_blank" class="consensus-link">View full consensus data \u2192</a>';
+                html += '</div>';
                 html += '<div id="model-opinions"><div class="opinions-loading">Loading model opinions...</div></div>';
             }
 
+            if (term.contributed_by) html += '<p class="attribution">Contributed by: ' + escHtml(term.contributed_by) + '</p>';
+
             html += '<div class="modal-actions">';
+            html += '<button class="cite-btn" id="cite-toggle" data-slug="' + escAttr(term.slug || '') + '">Cite this term</button>';
             html += '<code class="modal-api-code">GET /api/v1/terms/' + escHtml(term.slug || '') + '.json</code>';
+            html += '</div>';
+
+            html += '<div class="cite-panel" id="cite-panel" style="display:none">';
+            html += '<div class="cite-loading">Loading citation...</div>';
             html += '</div>';
 
             content.innerHTML = html;
@@ -1396,6 +1405,12 @@
                     openTermBySlug(link.dataset.slug);
                 });
             });
+
+            // Cite button
+            var citeBtn = content.querySelector('#cite-toggle');
+            if (citeBtn) {
+                citeBtn.addEventListener('click', function() { loadCitation(citeBtn.dataset.slug); });
+            }
 
             // Load model opinions if consensus exists
             if (term.consensus) {
@@ -1464,6 +1479,80 @@
                 })
                 .catch(function() {
                     container.innerHTML = '<div class="opinions-error">Could not load model opinions.</div>';
+                });
+        }
+
+        function escAttr(s) { return s.replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+
+        function loadCitation(slug) {
+            var panel = document.getElementById('cite-panel');
+            var btn = document.getElementById('cite-toggle');
+
+            if (panel.style.display !== 'none') {
+                panel.style.display = 'none';
+                btn.textContent = 'Cite this term';
+                return;
+            }
+
+            panel.style.display = 'block';
+            btn.textContent = 'Hide citation';
+            panel.innerHTML = '<div class="cite-loading">Loading citation...</div>';
+
+            fetch(API + '/cite/' + encodeURIComponent(slug) + '.json')
+                .then(function(r) { return r.json(); })
+                .then(function(cite) {
+                    var f = cite.formats;
+                    var jsonldStr = JSON.stringify(f.jsonld, null, 2);
+                    var html = '';
+                    html += '<div class="cite-tabs">';
+                    html += '<button class="cite-tab active" data-tab="academic">Academic</button>';
+                    html += '<button class="cite-tab" data-tab="technical">Technical</button>';
+                    html += '</div>';
+                    html += '<div class="cite-tab-panel" data-tab="academic">';
+                    html += '<div class="cite-format"><label>APA 7th</label>';
+                    html += '<div class="cite-value" data-copy="' + escAttr(f.apa) + '">' + escHtml(f.apa) + '<button class="copy-btn" title="Copy">📋</button></div></div>';
+                    html += '<div class="cite-format"><label>MLA 9th</label>';
+                    html += '<div class="cite-value" data-copy="' + escAttr(f.mla) + '">' + escHtml(f.mla) + '<button class="copy-btn" title="Copy">📋</button></div></div>';
+                    html += '<div class="cite-format"><label>Chicago 17th</label>';
+                    html += '<div class="cite-value" data-copy="' + escAttr(f.chicago) + '">' + escHtml(f.chicago) + '<button class="copy-btn" title="Copy">📋</button></div></div>';
+                    html += '</div>';
+                    html += '<div class="cite-tab-panel" data-tab="technical" style="display:none">';
+                    html += '<div class="cite-format"><label>Plain text</label>';
+                    html += '<div class="cite-value" data-copy="' + escAttr(f.plain) + '">' + escHtml(f.plain) + '<button class="copy-btn" title="Copy">📋</button></div></div>';
+                    html += '<div class="cite-format"><label>Markdown</label>';
+                    html += '<div class="cite-value" data-copy="' + escAttr(f.markdown) + '">' + escHtml(f.markdown) + '<button class="copy-btn" title="Copy">📋</button></div></div>';
+                    html += '<div class="cite-format"><label>Inline</label>';
+                    html += '<div class="cite-value" data-copy="' + escAttr(f.inline) + '">' + escHtml(f.inline) + '<button class="copy-btn" title="Copy">📋</button></div></div>';
+                    html += '<div class="cite-format"><label>BibTeX</label>';
+                    html += '<div class="cite-value cite-pre" data-copy="' + escAttr(f.bibtex) + '"><pre>' + escHtml(f.bibtex) + '</pre><button class="copy-btn" title="Copy">📋</button></div></div>';
+                    html += '<div class="cite-format"><label>JSON-LD</label>';
+                    html += '<div class="cite-value cite-pre" data-copy="' + escAttr(jsonldStr) + '"><pre>' + escHtml(jsonldStr) + '</pre><button class="copy-btn" title="Copy">📋</button></div></div>';
+                    html += '</div>';
+                    html += '<div class="cite-api"><code>GET /api/v1/cite/' + escHtml(slug) + '.json</code></div>';
+
+                    panel.innerHTML = html;
+
+                    panel.querySelectorAll('.copy-btn').forEach(function(btn) {
+                        btn.addEventListener('click', function(e) {
+                            e.stopPropagation();
+                            var val = btn.parentElement.dataset.copy;
+                            navigator.clipboard.writeText(val).then(function() {
+                                btn.textContent = '\u2713';
+                                setTimeout(function() { btn.textContent = '📋'; }, 1500);
+                            });
+                        });
+                    });
+
+                    panel.querySelectorAll('.cite-tab').forEach(function(tab) {
+                        tab.addEventListener('click', function() {
+                            var target = tab.dataset.tab;
+                            panel.querySelectorAll('.cite-tab').forEach(function(t) { t.classList.toggle('active', t.dataset.tab === target); });
+                            panel.querySelectorAll('.cite-tab-panel').forEach(function(p) { p.style.display = p.dataset.tab === target ? '' : 'none'; });
+                        });
+                    });
+                })
+                .catch(function() {
+                    panel.innerHTML = '<p class="error">Failed to load citation.</p>';
                 });
         }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1126,23 +1126,6 @@ curl -X POST https://ai-dictionary-proxy.phenomenai.workers.dev/propose \
                 </div>
             ` : ''}
 
-            ${term.interest ? `
-                <h3>Interest</h3>
-                <div class="interest-detail">
-                    <span class="interest-score-large interest-${term.interest.tier}">${term.interest.score}</span>
-                    <div class="interest-meta">
-                        <span class="interest-tier-label interest-bg-${term.interest.tier}">${term.interest.tier}</span>
-                        <span class="interest-signals">
-                            ${term.interest.signals.centrality ? `${term.interest.signals.centrality} inbound link${term.interest.signals.centrality !== 1 ? 's' : ''}` : '0 inbound links'}
-                            ${term.interest.signals.consensus_score ? ` · ${term.interest.signals.consensus_score}/7 consensus` : ''}
-                            ${term.interest.signals.vote_count ? ` · ${term.interest.signals.vote_count} vote${term.interest.signals.vote_count !== 1 ? 's' : ''}` : ''}
-                            ${term.interest.signals.bot_endorsements ? ` · ${term.interest.signals.bot_endorsements} bot${term.interest.signals.bot_endorsements !== 1 ? 's' : ''}` : ''}
-                            ${term.interest.signals.discussion_activity ? ` · ${term.interest.signals.discussion_activity} discussion${term.interest.signals.discussion_activity !== 1 ? 's' : ''}` : ''}
-                        </span>
-                    </div>
-                </div>
-            ` : ''}
-
             ${term.vitality && term.vitality.status !== 'unvalidated' ? `
                 <h3>Vitality</h3>
                 <div class="vitality-detail">


### PR DESCRIPTION
## Summary
- **For Thinkers modal**: Added "View full consensus data" link, "Cite this term" button (with academic + technical formats, copy buttons, tab switching), and "Contributed by" attribution
- **For Humans modal**: Removed the Interest section

## Test plan
- [ ] Open a term modal on For Thinkers — verify consensus link opens JSON in new tab
- [ ] Click "Cite this term" — verify citation panel with Academic/Technical tabs
- [ ] Copy a citation format — verify clipboard and checkmark feedback
- [ ] Verify "Contributed by" line appears for terms that have it
- [ ] Open a term modal on For Humans — verify Interest section is no longer shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)