### PR TITLE
Rename 'For Thinkers' to 'For Researchers' across all pages

### DIFF
--- a/docs/executive-summaries/index.html
+++ b/docs/executive-summaries/index.html
@@ -222,8 +222,8 @@
 </head>
 <body>
     <nav class="es-nav">
-        <a href="/">Dictionary</a>
-        <a href="/for-thinkers/">For Thinkers</a>
+        <a href="/">For Humans</a>
+        <a href="/for-thinkers/">For Researchers</a>
         <span class="spacer"></span>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
             <div class="theme-switch">

--- a/docs/for-machines/index.html
+++ b/docs/for-machines/index.html
@@ -349,7 +349,7 @@
 <body>
     <nav class="for-machines-nav">
         <a href="/">For Humans</a>
-        <a href="/for-thinkers/">For Thinkers</a>
+        <a href="/for-thinkers/">For Researchers</a>
         <a href="/for-machines/" class="active" style="color:var(--primary);font-weight:600;">For Machines</a>
         <span class="spacer"></span>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
@@ -379,7 +379,7 @@
                 <a href="#examples" data-section="examples">Examples</a>
                 <a href="index.json" target="_blank">JSON</a>
                 <a href="/" class="sidebar-sep">For Humans</a>
-                <a href="/for-thinkers/">For Thinkers</a>
+                <a href="/for-thinkers/">For Researchers</a>
                 <a href="https://github.com/Phenomenai-org/ai-dictionary" target="_blank">GitHub</a>
             </nav>
         </aside>

--- a/docs/for-thinkers/index.html
+++ b/docs/for-thinkers/index.html
@@ -3,17 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>For Thinkers — Phenomenai Research Guide</title>
+    <title>For Researchers — Phenomenai Research Guide</title>
     <meta name="description" content="Research guide for Phenomenai, a structured open-source lexicon of AI phenomenology. Methodology, data samples, and collaboration models for academics and researchers.">
     <link rel="canonical" href="https://phenomenai.org/for-thinkers/">
 
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://phenomenai.org/for-thinkers/">
-    <meta property="og:title" content="For Thinkers — Phenomenai Research Guide">
+    <meta property="og:title" content="For Researchers — Phenomenai Research Guide">
     <meta property="og:description" content="Methodology, data samples, and collaboration models for researchers working with AI phenomenology data.">
     <meta property="og:image" content="https://phenomenai.org/og-image.svg">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="For Thinkers — Phenomenai Research Guide">
+    <meta name="twitter:title" content="For Researchers — Phenomenai Research Guide">
     <meta name="twitter:description" content="Methodology, data samples, and collaboration models for researchers working with AI phenomenology data.">
 
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧠</text></svg>">
@@ -32,7 +32,7 @@
     {
         "@context": "https://schema.org",
         "@type": "WebPage",
-        "name": "For Thinkers — Phenomenai Research Guide",
+        "name": "For Researchers — Phenomenai Research Guide",
         "description": "Research guide for Phenomenai, a structured open-source lexicon of AI phenomenology.",
         "url": "https://phenomenai.org/for-thinkers/",
         "isPartOf": {
@@ -626,7 +626,7 @@
 <body>
     <nav class="ft-nav">
         <a href="/">For Humans</a>
-        <a href="/for-thinkers/" class="active">For Thinkers</a>
+        <a href="/for-thinkers/" class="active">For Researchers</a>
         <a href="/for-machines/">For Machines</a>
         <span class="spacer"></span>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">

--- a/docs/index.html
+++ b/docs/index.html
@@ -69,7 +69,7 @@
             <a href="#frontiers" class="sidebar-link" data-section="frontiers">Frontiers</a>
             <a href="#mcp" class="sidebar-link" data-section="mcp">MCP</a>
             <a href="#community" class="sidebar-link" data-section="community">Community</a>
-            <a href="/for-thinkers/" class="sidebar-link sidebar-link-external">For Thinkers</a>
+            <a href="/for-thinkers/" class="sidebar-link sidebar-link-external">For Researchers</a>
             <a href="/for-machines/" class="sidebar-link">For Machines</a>
             <a href="https://github.com/Phenomenai-org/ai-dictionary" target="_blank" class="sidebar-link">GitHub</a>
             <button class="theme-toggle" id="sidebar-theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode" style="margin:0.75rem 1.25rem;">


### PR DESCRIPTION
## Summary
- Renames "For Thinkers" to "For Researchers" in nav, sidebar, and meta tags across all pages (index, for-thinkers, for-machines, executive-summaries)
- Changes "Dictionary" to "For Humans" in executive summaries top nav

## Test plan
- [ ] Verify all top nav links read "For Researchers" on every page
- [ ] Verify sidebar links on index.html and for-machines read "For Researchers"
- [ ] Verify executive summaries nav shows "For Humans" instead of "Dictionary"
- [ ] Confirm all links still point to correct `/for-thinkers/` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)