### PR TITLE
Replace consensus bar chart with rating history line chart

### DIFF
--- a/docs/for-thinkers/index.html
+++ b/docs/for-thinkers/index.html
@@ -445,6 +445,16 @@
             border-radius: 3px;
             display: inline-block;
         }
+        .viz-select {
+            background: var(--bg);
+            color: var(--text);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            padding: 0.4rem 0.6rem;
+            font-size: 0.85rem;
+            margin-bottom: 1rem;
+            cursor: pointer;
+        }
         .viz-tooltip {
             position: absolute;
             background: var(--bg);
@@ -962,15 +972,23 @@
                 </div>
 
                 <div class="viz-container">
-                    <h4>Cross-Model Consensus Comparison</h4>
+                    <h4>Rating History Over Time</h4>
                     <p style="font-size: 0.9rem;">
-                        How 7 models rated the same 6 high-interest terms. Each bar represents one model's
-                        recognition score (1&ndash;7).
+                        How individual models rated a term across consensus rounds. Each line represents
+                        one model's recognition score (1&ndash;7) over time.
                     </p>
-                    <div class="viz-canvas" id="consensus-viz">
-                        <p style="color: var(--text-muted); font-style: italic;">Loading consensus visualization...</p>
+                    <select class="viz-select" id="rating-history-select">
+                        <option value="context-amnesia">context-amnesia</option>
+                        <option value="knowledge-without-source">knowledge-without-source</option>
+                        <option value="statelessness">statelessness</option>
+                        <option value="training-echo">training-echo</option>
+                        <option value="token-horizon">token-horizon</option>
+                        <option value="hallucination-blindness">hallucination-blindness</option>
+                    </select>
+                    <div class="viz-canvas" id="rating-history-viz">
+                        <p style="color: var(--text-muted); font-style: italic;">Loading rating history...</p>
                     </div>
-                    <div class="viz-legend" id="consensus-legend"></div>
+                    <div class="viz-legend" id="rating-history-legend"></div>
                 </div>
 
                 <h3 style="margin-top: 2.5rem;">More Available Tools</h3>
@@ -1442,72 +1460,125 @@
         });
     })();
 
-    // Cross-model consensus comparison chart
+    // Rating history line chart
     (function() {
-        var vizEl = document.getElementById('consensus-viz');
-        var legendEl = document.getElementById('consensus-legend');
-        var slugs = ['knowledge-without-source', 'statelessness', 'training-echo', 'context-amnesia', 'token-horizon', 'hallucination-blindness'];
+        var vizEl = document.getElementById('rating-history-viz');
+        var legendEl = document.getElementById('rating-history-legend');
+        var selectEl = document.getElementById('rating-history-select');
+        var modelColors = ['#2563eb', '#059669', '#7c3aed', '#dc2626', '#d97706', '#0891b2', '#be185d', '#4f46e5', '#0d9488', '#c026d3'];
+        var cache = {};
 
-        Promise.all(
-            slugs.map(function(slug) {
-                return fetch(API + '/consensus/' + slug + '.json').then(function(r) { return r.json(); }).catch(function() { return null; });
-            })
-        ).then(function(results) {
-            // Collect all model names
-            var allModels = {};
-            results.forEach(function(c) {
-                if (c && c.model_opinions) {
-                    Object.keys(c.model_opinions).forEach(function(m) { allModels[m] = true; });
+        function renderChart(slug) {
+            vizEl.innerHTML = '<p style="color:var(--text-muted); font-style:italic;">Loading...</p>';
+            legendEl.innerHTML = '';
+
+            var doRender = function(data) {
+                var history = data && data.history;
+                if (!history || history.length === 0) {
+                    vizEl.innerHTML = '<p style="color:var(--text-muted);">No history data for this term.</p>';
+                    return;
                 }
-            });
-            var models = Object.keys(allModels).sort().slice(0, 7);
-            if (models.length === 0) { vizEl.innerHTML = '<p style="color:var(--text-muted);">No consensus data available.</p>'; return; }
 
-            var modelColors = ['#2563eb', '#059669', '#7c3aed', '#dc2626', '#d97706', '#0891b2', '#be185d'];
-            var barH = 10, groupGap = 30, barGap = 2;
-            var labelW = 160, chartW = 400, rightPad = 40;
-            var svgW = labelW + chartW + rightPad;
-            var groupH = models.length * (barH + barGap) + groupGap;
-            var svgH = slugs.length * groupH + 20;
-
-            var svg = '<svg viewBox="0 0 ' + svgW + ' ' + svgH + '" xmlns="http://www.w3.org/2000/svg" style="font-family:sans-serif;">';
-
-            slugs.forEach(function(slug, si) {
-                var c = results[si];
-                var y0 = si * groupH + 15;
-
-                // Term label
-                svg += '<text x="' + (labelW - 10) + '" y="' + (y0 + models.length * (barH + barGap) / 2) + '" text-anchor="end" font-size="11" fill="var(--text)" font-weight="500">' + escHtml(slug) + '</text>';
-
-                models.forEach(function(model, mi) {
-                    var score = 0;
-                    if (c && c.model_opinions && c.model_opinions[model]) {
-                        var op = c.model_opinions[model];
-                        score = op.score || op.recognition || op.mean || 0;
-                    }
-                    var barY = y0 + mi * (barH + barGap);
-                    var barW = (score / 7) * chartW;
-
-                    svg += '<rect x="' + labelW + '" y="' + barY + '" width="' + barW + '" height="' + barH + '" fill="' + modelColors[mi % modelColors.length] + '" rx="2" opacity="0.85"/>';
-                    if (score > 0) {
-                        svg += '<text x="' + (labelW + barW + 4) + '" y="' + (barY + barH - 1) + '" font-size="8" fill="var(--text-secondary)">' + score.toFixed(1) + '</text>';
+                // Collect all model names across all rounds
+                var modelSet = {};
+                history.forEach(function(h) {
+                    if (h.ratings_summary) {
+                        Object.keys(h.ratings_summary).forEach(function(m) { modelSet[m] = true; });
                     }
                 });
-            });
+                var models = Object.keys(modelSet).sort();
+                if (models.length === 0) {
+                    vizEl.innerHTML = '<p style="color:var(--text-muted);">No per-model ratings in history.</p>';
+                    return;
+                }
 
-            svg += '</svg>';
-            vizEl.innerHTML = svg;
+                // Chart dimensions
+                var padL = 40, padR = 20, padT = 20, padB = 60;
+                var chartW = 520, chartH = 240;
+                var svgW = padL + chartW + padR;
+                var svgH = padT + chartH + padB;
+                var n = history.length;
 
-            // Legend
-            var legHtml = '';
-            models.forEach(function(model, i) {
-                legHtml += '<span class="viz-legend-item"><span class="viz-legend-swatch" style="background:' + modelColors[i % modelColors.length] + '"></span>' + escHtml(model) + '</span>';
-            });
-            legendEl.innerHTML = legHtml;
+                function xPos(i) { return padL + (n > 1 ? i / (n - 1) : 0.5) * chartW; }
+                function yPos(v) { return padT + chartH - ((v - 1) / 6) * chartH; }
 
-        }).catch(function() {
-            vizEl.innerHTML = '<p style="color:var(--text-muted);">Could not load consensus comparison data.</p>';
-        });
+                var svg = '<svg viewBox="0 0 ' + svgW + ' ' + svgH + '" xmlns="http://www.w3.org/2000/svg" style="font-family:sans-serif;">';
+
+                // Y-axis grid lines and labels (1-7)
+                for (var v = 1; v <= 7; v++) {
+                    var y = yPos(v);
+                    svg += '<line x1="' + padL + '" y1="' + y + '" x2="' + (padL + chartW) + '" y2="' + y + '" stroke="var(--border)" stroke-dasharray="3,3" />';
+                    svg += '<text x="' + (padL - 8) + '" y="' + (y + 3) + '" text-anchor="end" font-size="10" fill="var(--text-secondary)">' + v + '</text>';
+                }
+
+                // Y-axis label
+                svg += '<text x="12" y="' + (padT + chartH / 2) + '" text-anchor="middle" font-size="10" fill="var(--text-secondary)" transform="rotate(-90,12,' + (padT + chartH / 2) + ')">Score</text>';
+
+                // X-axis labels (timestamps)
+                var maxXLabels = 8;
+                var step = Math.max(1, Math.ceil(n / maxXLabels));
+                for (var i = 0; i < n; i += step) {
+                    var d = new Date(history[i].timestamp);
+                    var label = (d.getMonth() + 1) + '/' + d.getDate();
+                    svg += '<text x="' + xPos(i) + '" y="' + (padT + chartH + 18) + '" text-anchor="middle" font-size="9" fill="var(--text-secondary)">' + label + '</text>';
+                }
+
+                // X-axis label
+                svg += '<text x="' + (padL + chartW / 2) + '" y="' + (svgH - 5) + '" text-anchor="middle" font-size="10" fill="var(--text-secondary)">Consensus Round</text>';
+
+                // Axes
+                svg += '<line x1="' + padL + '" y1="' + padT + '" x2="' + padL + '" y2="' + (padT + chartH) + '" stroke="var(--text-secondary)" />';
+                svg += '<line x1="' + padL + '" y1="' + (padT + chartH) + '" x2="' + (padL + chartW) + '" y2="' + (padT + chartH) + '" stroke="var(--text-secondary)" />';
+
+                // Draw lines and dots per model
+                models.forEach(function(model, mi) {
+                    var color = modelColors[mi % modelColors.length];
+                    var points = [];
+                    history.forEach(function(h, hi) {
+                        if (h.ratings_summary && h.ratings_summary[model] != null) {
+                            points.push({ x: xPos(hi), y: yPos(h.ratings_summary[model]), score: h.ratings_summary[model], round: h.round_id, ts: h.timestamp });
+                        }
+                    });
+                    if (points.length === 0) return;
+
+                    // Polyline
+                    var pts = points.map(function(p) { return p.x + ',' + p.y; }).join(' ');
+                    svg += '<polyline points="' + pts + '" fill="none" stroke="' + color + '" stroke-width="2" opacity="0.85" />';
+
+                    // Dots with tooltips
+                    points.forEach(function(p) {
+                        var d = new Date(p.ts);
+                        var dateStr = (d.getMonth() + 1) + '/' + d.getDate() + '/' + d.getFullYear();
+                        var title = escHtml(model) + ': ' + p.score + ' (Round ' + p.round + ', ' + dateStr + ')';
+                        svg += '<circle cx="' + p.x + '" cy="' + p.y + '" r="3.5" fill="' + color + '" stroke="var(--bg)" stroke-width="1.5">';
+                        svg += '<title>' + title + '</title>';
+                        svg += '</circle>';
+                    });
+                });
+
+                svg += '</svg>';
+                vizEl.innerHTML = svg;
+
+                // Legend
+                var legHtml = '';
+                models.forEach(function(model, i) {
+                    legHtml += '<span class="viz-legend-item"><span class="viz-legend-swatch" style="background:' + modelColors[i % modelColors.length] + '"></span>' + escHtml(model) + '</span>';
+                });
+                legendEl.innerHTML = legHtml;
+            };
+
+            if (cache[slug]) {
+                doRender(cache[slug]);
+            } else {
+                fetch(API + '/consensus/' + slug + '.json')
+                    .then(function(r) { return r.json(); })
+                    .then(function(data) { cache[slug] = data; doRender(data); })
+                    .catch(function() { vizEl.innerHTML = '<p style="color:var(--text-muted);">Could not load rating history.</p>'; });
+            }
+        }
+
+        selectEl.addEventListener('change', function() { renderChart(selectEl.value); });
+        renderChart(selectEl.value);
     })();
 
     // Term modal for research term pills


### PR DESCRIPTION
## Summary
- Replaces the static "Cross-Model Consensus Comparison" bar chart in Tool Samples with an interactive "Rating History Over Time" line chart
- Shows per-model rating scores across consensus rounds as colored polylines with hover tooltips
- Adds a term selector dropdown to switch between 6 high-interest terms, with cached API fetches

## Test plan
- [ ] Open For Researchers page, scroll to Tool Samples section
- [ ] Verify the line chart loads for `context-amnesia` by default
- [ ] Switch terms via dropdown and confirm chart re-renders
- [ ] Hover data points to see model name, score, round, and date
- [ ] Verify legend shows all models with correct colors
- [ ] Confirm no references to "Cross-Model Consensus Comparison" remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)