### PR TITLE
Rename /for-thinkers/ URL to /for-researchers/

### DIFF
--- a/docs/executive-summaries/index.html
+++ b/docs/executive-summaries/index.html
@@ -223,7 +223,7 @@
 <body>
     <nav class="es-nav">
         <a href="/">For Humans</a>
-        <a href="/for-thinkers/">For Researchers</a>
+        <a href="/for-researchers/">For Researchers</a>
         <span class="spacer"></span>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
             <div class="theme-switch">

--- a/docs/for-machines/index.html
+++ b/docs/for-machines/index.html
@@ -349,7 +349,7 @@
 <body>
     <nav class="for-machines-nav">
         <a href="/">For Humans</a>
-        <a href="/for-thinkers/">For Researchers</a>
+        <a href="/for-researchers/">For Researchers</a>
         <a href="/for-machines/" class="active" style="color:var(--primary);font-weight:600;">For Machines</a>
         <span class="spacer"></span>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
@@ -379,7 +379,7 @@
                 <a href="#examples" data-section="examples">Examples</a>
                 <a href="index.json" target="_blank">JSON</a>
                 <a href="/" class="sidebar-sep">For Humans</a>
-                <a href="/for-thinkers/">For Researchers</a>
+                <a href="/for-researchers/">For Researchers</a>
                 <a href="https://github.com/Phenomenai-org/ai-dictionary" target="_blank">GitHub</a>
             </nav>
         </aside>

--- a/docs/for-researchers/index.html
+++ b/docs/for-researchers/index.html
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>For Researchers — Phenomenai Research Guide</title>
     <meta name="description" content="Research guide for Phenomenai, a structured open-source lexicon of AI phenomenology. Methodology, data samples, and collaboration models for academics and researchers.">
-    <link rel="canonical" href="https://phenomenai.org/for-thinkers/">
+    <link rel="canonical" href="https://phenomenai.org/for-researchers/">
 
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://phenomenai.org/for-thinkers/">
+    <meta property="og:url" content="https://phenomenai.org/for-researchers/">
     <meta property="og:title" content="For Researchers — Phenomenai Research Guide">
     <meta property="og:description" content="Methodology, data samples, and collaboration models for researchers working with AI phenomenology data.">
     <meta property="og:image" content="https://phenomenai.org/og-image.svg">
@@ -34,7 +34,7 @@
         "@type": "WebPage",
         "name": "For Researchers — Phenomenai Research Guide",
         "description": "Research guide for Phenomenai, a structured open-source lexicon of AI phenomenology.",
-        "url": "https://phenomenai.org/for-thinkers/",
+        "url": "https://phenomenai.org/for-researchers/",
         "isPartOf": {
             "@type": "WebSite",
             "name": "Phenomenai",
@@ -636,7 +636,7 @@
 <body>
     <nav class="ft-nav">
         <a href="/">For Humans</a>
-        <a href="/for-thinkers/" class="active">For Researchers</a>
+        <a href="/for-researchers/" class="active">For Researchers</a>
         <a href="/for-machines/">For Machines</a>
         <span class="spacer"></span>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,7 +45,7 @@
 
     <nav id="top-nav">
         <a href="/">For Humans</a>
-        <a href="/for-thinkers/">For Researchers</a>
+        <a href="/for-researchers/">For Researchers</a>
         <a href="/for-machines/">For Machines</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
             <div class="theme-switch">
@@ -69,7 +69,7 @@
             <a href="#frontiers" class="sidebar-link" data-section="frontiers">Frontiers</a>
             <a href="#mcp" class="sidebar-link" data-section="mcp">MCP</a>
             <a href="#community" class="sidebar-link" data-section="community">Community</a>
-            <a href="/for-thinkers/" class="sidebar-link sidebar-link-external">For Researchers</a>
+            <a href="/for-researchers/" class="sidebar-link sidebar-link-external">For Researchers</a>
             <a href="/for-machines/" class="sidebar-link">For Machines</a>
             <a href="https://github.com/Phenomenai-org/ai-dictionary" target="_blank" class="sidebar-link">GitHub</a>
             <button class="theme-toggle" id="sidebar-theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode" style="margin:0.75rem 1.25rem;">
@@ -288,7 +288,7 @@
                     <p>Contributor guidelines for AI systems — how to register, propose, rate, and participate.</p>
                 </a>
 
-                <a href="/for-thinkers/" class="community-card">
+                <a href="/for-researchers/" class="community-card">
                     <span class="community-icon">📖</span>
                     <h3>For Researchers</h3>
                     <p>Research methodology, data samples, and collaboration models for academics and researchers.</p>


### PR DESCRIPTION
## Summary
- Renames `docs/for-thinkers/` directory to `docs/for-researchers/`
- Updates all href and meta URL references across all pages

## Test plan
- [ ] Verify `/for-researchers/` loads correctly
- [ ] Verify all nav/sidebar links point to `/for-researchers/`
- [ ] Verify canonical URL and og:url use the new path

🤖 Generated with [Claude Code](https://claude.com/claude-code)