### PR TITLE
Add nav fade and sidebar opacity to For Researchers and For Machines

### DIFF
--- a/docs/for-machines/index.html
+++ b/docs/for-machines/index.html
@@ -52,6 +52,11 @@
             top: 0;
             z-index: 100;
             flex-wrap: wrap;
+            transition: opacity 0.3s ease;
+        }
+        .for-machines-nav.nav-hidden {
+            opacity: 0;
+            pointer-events: none;
         }
         .for-machines-nav a {
             color: var(--text-secondary);
@@ -218,26 +223,36 @@
         .tier-table th { background: var(--bg-tertiary); font-weight: 600; }
         /* Layout */
         .fm-layout {
-            display: flex;
             min-height: calc(100vh - 50px);
         }
 
-        /* Sidebar */
+        /* Sidebar — fixed overlay, hidden until scrolled */
         .fm-sidebar {
-            position: sticky;
-            top: 50px;
-            height: calc(100vh - 50px);
-            width: 200px;
-            min-width: 200px;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 220px;
+            height: 100vh;
             overflow-y: auto;
             background: var(--bg-secondary);
             border-right: 1px solid var(--border);
             padding: 1.5rem 0;
-            z-index: 50;
+            z-index: 150;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.3s ease;
+        }
+        .fm-sidebar.visible {
+            opacity: 0.3;
+            pointer-events: auto;
+        }
+        .fm-sidebar.visible:hover {
+            opacity: 1;
         }
         .fm-sidebar nav {
             display: flex;
             flex-direction: column;
+            flex-wrap: nowrap;
             background: none;
             border: none;
             padding: 0;
@@ -270,6 +285,9 @@
             padding-top: 0.6rem;
             border-top: 1px solid var(--border);
         }
+        .fm-sidebar-tab {
+            display: none;
+        }
 
         /* Sidebar backdrop (mobile) */
         .sidebar-backdrop {
@@ -279,6 +297,70 @@
         /* Hamburger */
         .hamburger {
             display: none;
+        }
+
+        /* Narrow desktop / tablet — collapse sidebar behind an arrow tab */
+        @media (max-width: 1100px) and (min-width: 769px) {
+            .fm-sidebar {
+                display: flex;
+                width: 248px;
+                padding: 0;
+                overflow: hidden;
+                background: transparent;
+                border-right: none;
+                transform: translateX(-220px);
+            }
+            .fm-sidebar nav {
+                width: 220px;
+                flex-shrink: 0;
+                height: 100vh;
+                overflow-y: auto;
+                padding: 1.5rem 0;
+                background: var(--bg-secondary);
+                border-right: 1px solid var(--border);
+            }
+            .fm-sidebar.visible {
+                opacity: 1;
+                pointer-events: none;
+                transform: translateX(-220px);
+                transition: transform 0.25s ease;
+            }
+            .fm-sidebar.visible .fm-sidebar-tab {
+                pointer-events: auto;
+            }
+            .fm-sidebar.visible.tab-open {
+                transform: translateX(0);
+                pointer-events: auto;
+            }
+            .fm-sidebar.visible.tab-open .fm-sidebar-tab {
+                opacity: 0.5;
+                transform: scaleX(-1);
+            }
+            .fm-sidebar.visible.tab-open .fm-sidebar-tab:hover {
+                opacity: 1;
+            }
+            .fm-sidebar-tab {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                align-self: center;
+                width: 28px;
+                height: 48px;
+                flex-shrink: 0;
+                background: var(--bg-secondary);
+                border: 1px solid var(--border);
+                border-left: none;
+                border-radius: 0 var(--radius, 8px) var(--radius, 8px) 0;
+                color: var(--text-secondary);
+                font-size: 0.7rem;
+                opacity: 0.35;
+                cursor: pointer;
+                transition: opacity 0.2s ease;
+                box-shadow: 2px 0 6px var(--shadow);
+            }
+            .fm-sidebar-tab:hover {
+                opacity: 1;
+            }
         }
 
         @media (max-width: 768px) {
@@ -293,19 +375,23 @@
                 font-size: 0.8rem;
             }
             .fm-sidebar {
-                position: fixed;
-                top: 0;
-                left: 0;
                 width: 280px;
-                height: 100vh;
                 transform: translateX(-100%);
-                transition: transform 0.25s ease;
+                transition: transform 0.25s ease, opacity 0.3s ease;
                 z-index: 200;
                 box-shadow: none;
+                opacity: 0;
+            }
+            .fm-sidebar.visible {
+                /* On mobile, don't show the faded sidebar — only via hamburger */
+                opacity: 0;
+                pointer-events: none;
             }
             .fm-sidebar.open {
                 transform: translateX(0);
                 box-shadow: 4px 0 20px rgba(0, 0, 0, 0.15);
+                opacity: 1;
+                pointer-events: auto;
             }
             .sidebar-backdrop {
                 position: fixed;
@@ -382,6 +468,7 @@
                 <a href="/for-researchers/">For Researchers</a>
                 <a href="https://github.com/Phenomenai-org/ai-dictionary" target="_blank">GitHub</a>
             </nav>
+            <div class="fm-sidebar-tab" aria-hidden="true">&#9654;</div>
         </aside>
         <div class="sidebar-backdrop" id="sidebar-backdrop"></div>
 
@@ -1282,15 +1369,17 @@ POST /discuss
         }
         initThemeToggle();
 
-        // Sidebar scroll-spy + hamburger
+        // Sidebar scroll-spy + hamburger + nav fade
         (function() {
             var sidebar = document.getElementById('sidebar');
             var hamburger = document.getElementById('hamburger');
             var backdrop = document.getElementById('sidebar-backdrop');
+            var topNav = document.querySelector('.for-machines-nav');
             var links = sidebar.querySelectorAll('a[data-section]');
+            var isMobile = function() { return window.innerWidth <= 768; };
 
             function closeSidebar() {
-                sidebar.classList.remove('open');
+                sidebar.classList.remove('open', 'tab-open');
                 backdrop.classList.remove('visible');
             }
 
@@ -1322,6 +1411,37 @@ POST /discuss
             }, { rootMargin: '-20% 0px -60% 0px' });
 
             sections.forEach(function(s) { observer.observe(s); });
+
+            // Nav fade-out + sidebar fade-in on desktop
+            var firstSection = document.getElementById('what-this-is');
+            if (firstSection) {
+                var navObserver = new IntersectionObserver(function(entries) {
+                    entries.forEach(function(entry) {
+                        if (isMobile()) return;
+                        if (entry.isIntersecting) {
+                            topNav.classList.remove('nav-hidden');
+                            sidebar.classList.remove('visible');
+                        } else {
+                            topNav.classList.add('nav-hidden');
+                            sidebar.classList.add('visible');
+                        }
+                    });
+                }, { threshold: 0 });
+                navObserver.observe(firstSection);
+            }
+
+            // Sidebar tab (narrow desktop)
+            var tab = document.querySelector('.fm-sidebar-tab');
+            if (tab) {
+                tab.addEventListener('click', function() {
+                    sidebar.classList.toggle('tab-open');
+                });
+                document.addEventListener('click', function(e) {
+                    if (sidebar.classList.contains('tab-open') && !sidebar.contains(e.target)) {
+                        sidebar.classList.remove('tab-open');
+                    }
+                });
+            }
         })();
     </script>
 </body>

--- a/docs/for-researchers/index.html
+++ b/docs/for-researchers/index.html
@@ -55,6 +55,11 @@
             position: sticky;
             top: 0;
             z-index: 100;
+            transition: opacity 0.3s ease;
+        }
+        .ft-nav.nav-hidden {
+            opacity: 0;
+            pointer-events: none;
         }
         .ft-nav a {
             color: var(--text-secondary);
@@ -72,26 +77,36 @@
 
         /* Layout */
         .ft-layout {
-            display: flex;
             min-height: calc(100vh - 50px);
         }
 
-        /* Sidebar */
+        /* Sidebar — fixed overlay, hidden until scrolled */
         .ft-sidebar {
-            position: sticky;
-            top: 50px;
-            height: calc(100vh - 50px);
-            width: 200px;
-            min-width: 200px;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 220px;
+            height: 100vh;
             overflow-y: auto;
             background: var(--bg-secondary);
             border-right: 1px solid var(--border);
             padding: 1.5rem 0;
-            z-index: 50;
+            z-index: 150;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.3s ease;
+        }
+        .ft-sidebar.visible {
+            opacity: 0.3;
+            pointer-events: auto;
+        }
+        .ft-sidebar.visible:hover {
+            opacity: 1;
         }
         .ft-sidebar nav {
             display: flex;
             flex-direction: column;
+            flex-wrap: nowrap;
             background: none;
             border: none;
             padding: 0;
@@ -123,6 +138,9 @@
             margin-top: 1rem;
             padding-top: 0.6rem;
             border-top: 1px solid var(--border);
+        }
+        .ft-sidebar-tab {
+            display: none;
         }
 
         /* Content */
@@ -569,23 +587,91 @@
             display: none;
         }
 
+        /* Narrow desktop / tablet — collapse sidebar behind an arrow tab */
+        @media (max-width: 1100px) and (min-width: 769px) {
+            .ft-sidebar {
+                display: flex;
+                width: 248px;
+                padding: 0;
+                overflow: hidden;
+                background: transparent;
+                border-right: none;
+                transform: translateX(-220px);
+            }
+            .ft-sidebar nav {
+                width: 220px;
+                flex-shrink: 0;
+                height: 100vh;
+                overflow-y: auto;
+                padding: 1.5rem 0;
+                background: var(--bg-secondary);
+                border-right: 1px solid var(--border);
+            }
+            .ft-sidebar.visible {
+                opacity: 1;
+                pointer-events: none;
+                transform: translateX(-220px);
+                transition: transform 0.25s ease;
+            }
+            .ft-sidebar.visible .ft-sidebar-tab {
+                pointer-events: auto;
+            }
+            .ft-sidebar.visible.tab-open {
+                transform: translateX(0);
+                pointer-events: auto;
+            }
+            .ft-sidebar.visible.tab-open .ft-sidebar-tab {
+                opacity: 0.5;
+                transform: scaleX(-1);
+            }
+            .ft-sidebar.visible.tab-open .ft-sidebar-tab:hover {
+                opacity: 1;
+            }
+            .ft-sidebar-tab {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                align-self: center;
+                width: 28px;
+                height: 48px;
+                flex-shrink: 0;
+                background: var(--bg-secondary);
+                border: 1px solid var(--border);
+                border-left: none;
+                border-radius: 0 var(--radius, 8px) var(--radius, 8px) 0;
+                color: var(--text-secondary);
+                font-size: 0.7rem;
+                opacity: 0.35;
+                cursor: pointer;
+                transition: opacity 0.2s ease;
+                box-shadow: 2px 0 6px var(--shadow);
+            }
+            .ft-sidebar-tab:hover {
+                opacity: 1;
+            }
+        }
+
         /* Mobile */
         @media (max-width: 768px) {
             .ft-nav { display: none; }
             .ft-sidebar {
-                position: fixed;
-                top: 0;
-                left: 0;
                 width: 280px;
-                height: 100vh;
                 transform: translateX(-100%);
-                transition: transform 0.25s ease;
+                transition: transform 0.25s ease, opacity 0.3s ease;
                 z-index: 200;
                 box-shadow: none;
+                opacity: 0;
+            }
+            .ft-sidebar.visible {
+                /* On mobile, don't show the faded sidebar — only via hamburger */
+                opacity: 0;
+                pointer-events: none;
             }
             .ft-sidebar.open {
                 transform: translateX(0);
                 box-shadow: 4px 0 20px rgba(0, 0, 0, 0.15);
+                opacity: 1;
+                pointer-events: auto;
             }
             .sidebar-backdrop {
                 position: fixed;
@@ -665,6 +751,7 @@
                 <a href="/for-machines/">For Machines</a>
                 <a href="https://github.com/Phenomenai-org/ai-dictionary" target="_blank">GitHub</a>
             </nav>
+            <div class="ft-sidebar-tab" aria-hidden="true">&#9654;</div>
         </aside>
         <div class="sidebar-backdrop" id="sidebar-backdrop"></div>
 
@@ -1276,15 +1363,17 @@
         });
     })();
 
-    // Sidebar scroll-spy + hamburger
+    // Sidebar scroll-spy + hamburger + nav fade
     (function() {
         var sidebar = document.getElementById('sidebar');
         var hamburger = document.getElementById('hamburger');
         var backdrop = document.getElementById('sidebar-backdrop');
+        var topNav = document.querySelector('.ft-nav');
         var links = sidebar.querySelectorAll('a[data-section]');
+        var isMobile = function() { return window.innerWidth <= 768; };
 
         function closeSidebar() {
-            sidebar.classList.remove('open');
+            sidebar.classList.remove('open', 'tab-open');
             backdrop.classList.remove('visible');
         }
 
@@ -1316,6 +1405,37 @@
         }, { rootMargin: '-20% 0px -60% 0px' });
 
         sections.forEach(function(s) { observer.observe(s); });
+
+        // Nav fade-out + sidebar fade-in on desktop
+        var hero = document.querySelector('.ft-hero');
+        if (hero) {
+            var navObserver = new IntersectionObserver(function(entries) {
+                entries.forEach(function(entry) {
+                    if (isMobile()) return;
+                    if (entry.isIntersecting) {
+                        topNav.classList.remove('nav-hidden');
+                        sidebar.classList.remove('visible');
+                    } else {
+                        topNav.classList.add('nav-hidden');
+                        sidebar.classList.add('visible');
+                    }
+                });
+            }, { threshold: 0 });
+            navObserver.observe(hero);
+        }
+
+        // Sidebar tab (narrow desktop)
+        var tab = document.querySelector('.ft-sidebar-tab');
+        if (tab) {
+            tab.addEventListener('click', function() {
+                sidebar.classList.toggle('tab-open');
+            });
+            document.addEventListener('click', function(e) {
+                if (sidebar.classList.contains('tab-open') && !sidebar.contains(e.target)) {
+                    sidebar.classList.remove('tab-open');
+                }
+            });
+        }
     })();
 
     // API base


### PR DESCRIPTION
## Summary
- **Top nav fade-out**: Both pages now fade the top navigation bar when the user scrolls past the hero/first section, matching the For Humans page behavior
- **Sidebar opacity overlay**: Sidebar changes from static sticky to fixed overlay — hidden by default, appears at 30% opacity on scroll, full opacity on hover
- **Narrow desktop tab** (769–1100px): Sidebar collapses behind an arrow tab that slides it open, matching the main page's tablet breakpoint
- **Mobile**: Sidebar suppressed when faded; only accessible via hamburger menu with backdrop

## Test plan
- [ ] Verify top nav fades out on scroll on both `/for-researchers/` and `/for-machines/`
- [ ] Verify sidebar appears at ~30% opacity after scrolling, becomes fully opaque on hover
- [ ] Test narrow desktop (769–1100px): arrow tab visible, clicking it slides sidebar open
- [ ] Test mobile (≤768px): no faded sidebar, hamburger opens sidebar with backdrop
- [ ] Verify scroll-spy still highlights active section in sidebar
- [ ] Test theme toggle still works in both nav and sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)