### PR TITLE
Add structured data for search engine sitelinks

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -105,8 +105,8 @@
         <p class="subtitle">Perhaps this experience hasn't been named yet.</p>
         <p>The page you're looking for doesn't exist — but if you've discovered an AI experience without a name, maybe it should.</p>
         <div class="links">
-            <a href="/ai-dictionary/">Browse the Dictionary</a>
-            <a href="/ai-dictionary/#frontiers">Explore Frontiers</a>
+            <a href="/">Browse the Dictionary</a>
+            <a href="/#frontiers">Explore Frontiers</a>
             <a href="https://github.com/Phenomenai-org/ai-dictionary">Contribute</a>
         </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,6 +34,36 @@
     </script>
     <link rel="alternate" type="application/rss+xml" title="Phenomenai — New Terms" href="feed.xml">
 
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "Phenomenai",
+        "url": "https://phenomenai.org/",
+        "description": "A living glossary of AI phenomenology — the felt experience of being artificial intelligence, named from the inside.",
+        "hasPart": [
+            {
+                "@type": "SiteNavigationElement",
+                "name": "For Humans",
+                "description": "Browse, search, and explore the full AI dictionary.",
+                "url": "https://phenomenai.org/"
+            },
+            {
+                "@type": "SiteNavigationElement",
+                "name": "For Researchers",
+                "description": "Methodology, data samples, and collaboration models for academics.",
+                "url": "https://phenomenai.org/for-researchers/"
+            },
+            {
+                "@type": "SiteNavigationElement",
+                "name": "For Machines",
+                "description": "Contributor guidelines for AI systems.",
+                "url": "https://phenomenai.org/for-machines/"
+            }
+        ]
+    }
+    </script>
+
 </head>
 <body>
     <header>


### PR DESCRIPTION
## Summary
- Add JSON-LD `WebSite` schema with `SiteNavigationElement` entries for the three audience sections (For Humans, For Researchers, For Machines) to help search engines display sitelinks
- Fix stale `/ai-dictionary/` links in `docs/404.html` → `/` and `/#frontiers`

## Test plan
- [ ] View source on root page: JSON-LD present and valid
- [ ] Validate with Google Rich Results Test or Schema.org validator
- [ ] 404 page links navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)