### PR TITLE
Refine Term Explorer per-model stats and confidence colors

### DIFF
--- a/docs/for-researchers/index.html
+++ b/docs/for-researchers/index.html
@@ -504,13 +504,13 @@
             height: 100%;
             border-radius: 3px;
         }
-        .conf-high { background: rgba(34,197,94,0.15); color: #22c55e; }
+        .conf-high { background: rgba(34,197,94,0.12); color: #22c55e; }
         .conf-high .confidence-fill { background: #22c55e; }
-        .conf-moderate { background: rgba(245,158,11,0.15); color: #f59e0b; }
-        .conf-moderate .confidence-fill { background: #f59e0b; }
-        .conf-low { background: rgba(249,115,22,0.15); color: #f97316; }
-        .conf-low .confidence-fill { background: #f97316; }
-        .conf-very-low { background: rgba(239,68,68,0.15); color: #ef4444; }
+        .conf-moderate { background: rgba(147,160,178,0.15); color: var(--text-secondary); }
+        .conf-moderate .confidence-fill { background: var(--text-secondary); }
+        .conf-low { background: rgba(147,160,178,0.15); color: var(--text-muted); }
+        .conf-low .confidence-fill { background: var(--text-muted); }
+        .conf-very-low { background: rgba(239,68,68,0.12); color: #ef4444; }
         .conf-very-low .confidence-fill { background: #ef4444; }
 
         /* Per-model recognition rows in term explorer */
@@ -1885,7 +1885,6 @@
             if (mean !== null) h += '<span class="stat-pill">Mean: <strong>' + Number(mean).toFixed(1) + '</strong>/7</span>';
             if (agreement) h += '<span class="stat-pill">Agreement: <strong>' + escHtml(agreement) + '</strong></span>';
             if (stdDev !== null) h += '<span class="stat-pill">Std dev: <strong>' + Number(stdDev).toFixed(2) + '</strong></span>';
-            if (nTotal) h += '<span class="stat-pill"><strong>' + nTotal + '</strong> ratings from <strong>' + nModels + '</strong> models</span>';
 
             // Confidence indicator
             var conf = computeConfidence(consensus, nModels, nTotal, stdDev);
@@ -1913,7 +1912,8 @@
             if (consensus.model_opinions) {
                 h += '<div style="margin-top:0.5rem;"><h5 style="font-size:0.85rem;color:var(--text-secondary);margin-bottom:0.5rem;">Per-Model Recognition</h5>';
 
-                // Count ratings per model from history
+                // Collect per-model scores from history for self-congruence + rating counts
+                var modelScoresOnTerm = {}; // model -> [scores across rounds]
                 var modelRatingCounts = {};
                 if (consensus.history) {
                     for (var i = 0; i < consensus.history.length; i++) {
@@ -1922,10 +1922,15 @@
                             var rModels = Object.keys(rs);
                             for (var j = 0; j < rModels.length; j++) {
                                 modelRatingCounts[rModels[j]] = (modelRatingCounts[rModels[j]] || 0) + 1;
+                                if (!modelScoresOnTerm[rModels[j]]) modelScoresOnTerm[rModels[j]] = [];
+                                modelScoresOnTerm[rModels[j]].push(rs[rModels[j]]);
                             }
                         }
                     }
                 }
+
+                // Compute term mean for deviation calc
+                var termMean = mean !== null ? mean : 0;
 
                 var modelNames = Object.keys(consensus.model_opinions).sort();
                 for (var i = 0; i < modelNames.length; i++) {
@@ -1944,8 +1949,31 @@
                     h += '<span class="te-model-score">' + Number(score).toFixed(1) + '</span>';
                     h += '</div>';
 
+                    // Meta line: X/total ratings, self-congruence, deviation from mean
                     h += '<div class="te-model-meta">';
-                    h += '<span>' + rCount + ' rating' + (rCount !== 1 ? 's' : '') + '</span>';
+                    h += '<span>' + rCount + '/' + nTotal + ' ratings</span>';
+
+                    // Self-congruence on this term (std_dev of this model's scores across rounds)
+                    var mScores = modelScoresOnTerm[mName];
+                    if (mScores && mScores.length >= 2) {
+                        var mMean = 0;
+                        for (var k = 0; k < mScores.length; k++) mMean += mScores[k];
+                        mMean /= mScores.length;
+                        var mVariance = 0;
+                        for (var k = 0; k < mScores.length; k++) mVariance += (mScores[k] - mMean) * (mScores[k] - mMean);
+                        var mStd = Math.sqrt(mVariance / (mScores.length - 1));
+                        h += '<span>&sigma; ' + mStd.toFixed(2) + ' self</span>';
+                    } else {
+                        h += '<span>&sigma; n/a self</span>';
+                    }
+
+                    // Deviation from term mean
+                    if (termMean) {
+                        var dev = score - termMean;
+                        var devStr = (dev >= 0 ? '+' : '') + dev.toFixed(1);
+                        h += '<span>' + devStr + ' from mean</span>';
+                    }
+
                     if (justification) {
                         h += '<button class="te-justification-toggle" data-target="' + rowId + '">show justification</button>';
                     }


### PR DESCRIPTION
## Summary
- Remove redundant "X ratings from Y models" stat pill
- Each model row now shows: `X/total ratings`, self-congruence on that term (sigma of scores across rounds), and deviation from term mean (e.g. +1.7 from mean)
- Fix confidence indicator colors: moderate/low levels now use muted tones instead of garish orange/yellow

## Test plan
- [ ] Open Term Explorer, verify per-model meta shows 3 stats (ratings fraction, self sigma, deviation)
- [ ] Verify confidence indicator uses subtle colors (green for high, muted grey for mid-range, red for very low)
- [ ] Hover confidence badge to see factor breakdown
- [ ] Test dark and light themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)