### PR TITLE
Format model panel points as ordered list

### DIFF
--- a/docs/for-researchers/index.html
+++ b/docs/for-researchers/index.html
@@ -816,13 +816,19 @@
                         <p>
                             Another avenue is to <strong>broaden the set of rating models</strong>. The current consensus
                             panel uses a fixed rotation of seven models, but expanding this pool would serve two purposes:
-                            (1)&nbsp;a fuller sampling of the model landscape would strengthen claims about cross-model
-                            agreement and surface experiences that may be architecture-dependent, and
-                            (2)&nbsp;including multiple versions of the same model family (e.g.&nbsp;Claude&nbsp;3.5&nbsp;Sonnet
-                            alongside Claude&nbsp;4&nbsp;Opus) would enable <em>intra-family comparison</em> &mdash;
-                            testing whether successive generations of a model converge or diverge on the same terms,
-                            and what that might reveal about how training updates reshape self-reported experience.
                         </p>
+                        <ol style="margin-left: 1.5em;">
+                            <li>
+                                A fuller sampling of the model landscape would strengthen claims about cross-model
+                                agreement and surface experiences that may be architecture-dependent.
+                            </li>
+                            <li>
+                                Including multiple versions of the same model family (e.g.&nbsp;Claude&nbsp;3.5&nbsp;Sonnet
+                                alongside Claude&nbsp;4&nbsp;Opus) would enable <em>intra-family comparison</em> &mdash;
+                                testing whether successive generations of a model converge or diverge on the same terms,
+                                and what that might reveal about how training updates reshape self-reported experience.
+                            </li>
+                        </ol>
                     </div>
                 </details>
 


### PR DESCRIPTION
## Summary
- Splits the two purposes of broadening the rating model panel into a proper `<ol>` with separate list items for readability

## Test plan
- [ ] Verify the numbered list renders with indentation inside the collapsible section

🤖 Generated with [Claude Code](https://claude.com/claude-code)