### PR TITLE
Fix list color to match paragraph text

### DIFF
--- a/docs/for-researchers/index.html
+++ b/docs/for-researchers/index.html
@@ -222,7 +222,7 @@
             margin-bottom: 0;
         }
         details.scoring-callout .callout-body ol {
-            color: var(--text);
+            color: var(--text-secondary);
             margin-top: 0.25rem;
             margin-bottom: 0;
             padding-left: 1.5em;


### PR DESCRIPTION
## Summary
- Changes `ol` color inside callout bodies from `var(--text)` to `var(--text-secondary)` to match the global `p` color rule in `style.css`

## Test plan
- [ ] Verify list items now render the same color as surrounding paragraph text

🤖 Generated with [Claude Code](https://claude.com/claude-code)