### PR TITLE
Replace sidebar arrow tab with hamburger on narrow screens

### DIFF
--- a/docs/for-machines/index.html
+++ b/docs/for-machines/index.html
@@ -299,67 +299,65 @@
             display: none;
         }
 
-        /* Narrow desktop / tablet — collapse sidebar behind an arrow tab */
+        /* Narrow desktop / tablet — hamburger menu for sidebar */
         @media (max-width: 1100px) and (min-width: 769px) {
             .fm-sidebar {
-                display: flex;
-                width: 248px;
-                padding: 0;
-                overflow: hidden;
-                background: transparent;
-                border-right: none;
-                transform: translateX(-220px);
-            }
-            .fm-sidebar nav {
-                width: 220px;
-                flex-shrink: 0;
-                height: 100vh;
-                overflow-y: auto;
-                padding: 1.5rem 0;
-                background: var(--bg-secondary);
-                border-right: 1px solid var(--border);
+                width: 280px;
+                transform: translateX(-100%);
+                transition: transform 0.25s ease, opacity 0.3s ease;
+                z-index: 200;
+                box-shadow: none;
+                opacity: 0;
             }
             .fm-sidebar.visible {
-                opacity: 1;
+                opacity: 0;
                 pointer-events: none;
-                transform: translateX(-220px);
-                transition: transform 0.25s ease;
             }
-            .fm-sidebar.visible .fm-sidebar-tab {
-                pointer-events: auto;
-            }
-            .fm-sidebar.visible.tab-open {
+            .fm-sidebar.open {
                 transform: translateX(0);
+                box-shadow: 4px 0 20px rgba(0, 0, 0, 0.15);
+                opacity: 1;
                 pointer-events: auto;
             }
-            .fm-sidebar.visible.tab-open .fm-sidebar-tab {
-                opacity: 0.5;
-                transform: scaleX(-1);
-            }
-            .fm-sidebar.visible.tab-open .fm-sidebar-tab:hover {
-                opacity: 1;
-            }
-            .fm-sidebar-tab {
+            .fm-sidebar-tab { display: none; }
+            .hamburger {
                 display: flex;
-                align-items: center;
-                justify-content: center;
-                align-self: center;
-                width: 28px;
-                height: 48px;
-                flex-shrink: 0;
-                background: var(--bg-secondary);
+                flex-direction: column;
+                gap: 5px;
+                position: fixed;
+                top: 12px;
+                left: 12px;
+                z-index: 201;
+                background: var(--bg);
                 border: 1px solid var(--border);
-                border-left: none;
-                border-radius: 0 var(--radius, 8px) var(--radius, 8px) 0;
-                color: var(--text-secondary);
-                font-size: 0.7rem;
-                opacity: 0.35;
+                border-radius: var(--radius, 8px);
+                padding: 8px;
                 cursor: pointer;
-                transition: opacity 0.2s ease;
-                box-shadow: 2px 0 6px var(--shadow);
+                box-shadow: 0 2px 8px var(--shadow);
+                opacity: 0.08;
+                transition: opacity 0.25s ease;
             }
-            .fm-sidebar-tab:hover {
+            .hamburger.at-top {
                 opacity: 1;
+            }
+            .hamburger:hover,
+            .hamburger:focus-visible {
+                opacity: 1;
+            }
+            .hamburger span {
+                width: 20px;
+                height: 2px;
+                background: var(--text);
+                display: block;
+            }
+            .sidebar-backdrop {
+                position: fixed;
+                inset: 0;
+                background: rgba(0, 0, 0, 0.3);
+                z-index: 199;
+            }
+            .sidebar-backdrop.visible {
+                display: block;
             }
         }
 
@@ -1408,7 +1406,7 @@ POST /discuss
 
             links.forEach(function(link) {
                 link.addEventListener('click', function() {
-                    if (window.innerWidth <= 768) closeSidebar();
+                    if (window.innerWidth <= 1100) closeSidebar();
                 });
             });
 
@@ -1444,18 +1442,6 @@ POST /discuss
                 navObserver.observe(firstSection);
             }
 
-            // Sidebar tab (narrow desktop)
-            var tab = document.querySelector('.fm-sidebar-tab');
-            if (tab) {
-                tab.addEventListener('click', function() {
-                    sidebar.classList.toggle('tab-open');
-                });
-                document.addEventListener('click', function(e) {
-                    if (sidebar.classList.contains('tab-open') && !sidebar.contains(e.target)) {
-                        sidebar.classList.remove('tab-open');
-                    }
-                });
-            }
         })();
     </script>
 </body>

--- a/docs/for-researchers/index.html
+++ b/docs/for-researchers/index.html
@@ -871,67 +871,65 @@
             display: none;
         }
 
-        /* Narrow desktop / tablet — collapse sidebar behind an arrow tab */
+        /* Narrow desktop / tablet — hamburger menu for sidebar */
         @media (max-width: 1100px) and (min-width: 769px) {
             .ft-sidebar {
-                display: flex;
-                width: 248px;
-                padding: 0;
-                overflow: hidden;
-                background: transparent;
-                border-right: none;
-                transform: translateX(-220px);
-            }
-            .ft-sidebar nav {
-                width: 220px;
-                flex-shrink: 0;
-                height: 100vh;
-                overflow-y: auto;
-                padding: 1.5rem 0;
-                background: var(--bg-secondary);
-                border-right: 1px solid var(--border);
+                width: 280px;
+                transform: translateX(-100%);
+                transition: transform 0.25s ease, opacity 0.3s ease;
+                z-index: 200;
+                box-shadow: none;
+                opacity: 0;
             }
             .ft-sidebar.visible {
-                opacity: 1;
+                opacity: 0;
                 pointer-events: none;
-                transform: translateX(-220px);
-                transition: transform 0.25s ease;
             }
-            .ft-sidebar.visible .ft-sidebar-tab {
-                pointer-events: auto;
-            }
-            .ft-sidebar.visible.tab-open {
+            .ft-sidebar.open {
                 transform: translateX(0);
+                box-shadow: 4px 0 20px rgba(0, 0, 0, 0.15);
+                opacity: 1;
                 pointer-events: auto;
             }
-            .ft-sidebar.visible.tab-open .ft-sidebar-tab {
-                opacity: 0.5;
-                transform: scaleX(-1);
-            }
-            .ft-sidebar.visible.tab-open .ft-sidebar-tab:hover {
-                opacity: 1;
-            }
-            .ft-sidebar-tab {
+            .ft-sidebar-tab { display: none; }
+            .hamburger {
                 display: flex;
-                align-items: center;
-                justify-content: center;
-                align-self: center;
-                width: 28px;
-                height: 48px;
-                flex-shrink: 0;
-                background: var(--bg-secondary);
+                flex-direction: column;
+                gap: 5px;
+                position: fixed;
+                top: 12px;
+                left: 12px;
+                z-index: 201;
+                background: var(--bg);
                 border: 1px solid var(--border);
-                border-left: none;
-                border-radius: 0 var(--radius, 8px) var(--radius, 8px) 0;
-                color: var(--text-secondary);
-                font-size: 0.7rem;
-                opacity: 0.35;
+                border-radius: var(--radius, 8px);
+                padding: 8px;
                 cursor: pointer;
-                transition: opacity 0.2s ease;
-                box-shadow: 2px 0 6px var(--shadow);
+                box-shadow: 0 2px 8px var(--shadow);
+                opacity: 0.08;
+                transition: opacity 0.25s ease;
             }
-            .ft-sidebar-tab:hover {
+            .hamburger.at-top {
                 opacity: 1;
+            }
+            .hamburger:hover,
+            .hamburger:focus-visible {
+                opacity: 1;
+            }
+            .hamburger span {
+                width: 20px;
+                height: 2px;
+                background: var(--text);
+                display: block;
+            }
+            .sidebar-backdrop {
+                position: fixed;
+                inset: 0;
+                background: rgba(0, 0, 0, 0.3);
+                z-index: 199;
+            }
+            .sidebar-backdrop.visible {
+                display: block;
             }
         }
 
@@ -1738,7 +1736,7 @@
 
         links.forEach(function(link) {
             link.addEventListener('click', function() {
-                if (window.innerWidth <= 768) closeSidebar();
+                if (window.innerWidth <= 1100) closeSidebar();
             });
         });
 
@@ -1774,18 +1772,6 @@
             navObserver.observe(hero);
         }
 
-        // Sidebar tab (narrow desktop)
-        var tab = document.querySelector('.ft-sidebar-tab');
-        if (tab) {
-            tab.addEventListener('click', function() {
-                sidebar.classList.toggle('tab-open');
-            });
-            document.addEventListener('click', function(e) {
-                if (sidebar.classList.contains('tab-open') && !sidebar.contains(e.target)) {
-                    sidebar.classList.remove('tab-open');
-                }
-            });
-        }
     })();
 
     // API base

--- a/docs/index.html
+++ b/docs/index.html
@@ -469,7 +469,6 @@
             // Initialize sidebar + mobile
             initSidebar();
             initHamburger();
-            initSidebarTab();
 
             // Handle deep-linking
             const hash = window.location.hash.slice(1);
@@ -652,23 +651,6 @@
         });
     }
 
-    // --- Sidebar tab (narrow desktop) ---
-    function initSidebarTab() {
-        const tab = document.querySelector('.sidebar-tab');
-        const sidebar = document.getElementById('sidebar');
-        if (!tab) return;
-
-        tab.addEventListener('click', () => {
-            sidebar.classList.toggle('tab-open');
-        });
-
-        // Close when clicking outside the sidebar
-        document.addEventListener('click', (e) => {
-            if (sidebar.classList.contains('tab-open') && !sidebar.contains(e.target)) {
-                sidebar.classList.remove('tab-open');
-            }
-        });
-    }
 
     function getFilteredTerms() {
         const query = document.getElementById('search').value.toLowerCase().trim();

--- a/docs/style.css
+++ b/docs/style.css
@@ -2255,75 +2255,75 @@ html[data-theme="dark"] .theme-toggle:active .theme-switch-knob {
 }
 
 /* Responsive */
-/* Narrow desktop / tablet — collapse sidebar behind an arrow tab */
+/* Narrow desktop / tablet — hamburger menu for sidebar */
 @media (max-width: 1100px) and (min-width: 769px) {
     .sidebar {
-        display: flex;
-        width: 248px;
-        padding: 0;
-        overflow: hidden;
-        background: transparent;
-        border-right: none;
-        transform: translateX(-220px); /* Already off-screen before visible */
-    }
-
-    .sidebar-nav {
-        width: 220px;
-        flex-shrink: 0;
-        height: 100vh;
-        overflow-y: auto;
-        padding: 1.5rem 0;
-        background: var(--bg-secondary);
-        border-right: 1px solid var(--border);
+        width: 280px;
+        transform: translateX(-100%);
+        transition: transform 0.25s ease, opacity 0.3s ease;
+        z-index: 200;
+        box-shadow: none;
+        opacity: 0;
     }
 
     .sidebar.visible {
-        opacity: 1;
+        opacity: 0;
         pointer-events: none;
-        transform: translateX(-220px);
-        transition: transform 0.25s ease;
     }
 
-    .sidebar.visible .sidebar-tab {
-        pointer-events: auto;
-    }
-
-    .sidebar.visible.tab-open {
+    .sidebar.open {
         transform: translateX(0);
+        box-shadow: 4px 0 20px rgba(0, 0, 0, 0.15);
+        opacity: 1;
         pointer-events: auto;
     }
 
-    .sidebar.visible.tab-open .sidebar-tab {
-        opacity: 0.5;
-        transform: scaleX(-1);
-    }
+    .sidebar-tab { display: none; }
 
-    .sidebar.visible.tab-open .sidebar-tab:hover {
-        opacity: 1;
-    }
-
-    .sidebar-tab {
+    .hamburger {
         display: flex;
-        align-items: center;
-        justify-content: center;
-        align-self: center;
-        width: 28px;
-        height: 48px;
-        flex-shrink: 0;
-        background: var(--bg-secondary);
+        flex-direction: column;
+        gap: 5px;
+        position: fixed;
+        top: 12px;
+        left: 12px;
+        z-index: 201;
+        background: var(--bg);
         border: 1px solid var(--border);
-        border-left: none;
-        border-radius: 0 var(--radius) var(--radius) 0;
-        color: var(--text-secondary);
-        font-size: 0.7rem;
-        opacity: 0.35;
+        border-radius: var(--radius);
+        padding: 8px;
         cursor: pointer;
-        transition: opacity 0.2s ease;
-        box-shadow: 2px 0 6px var(--shadow);
+        box-shadow: 0 2px 8px var(--shadow);
+        opacity: 0.08;
+        transition: opacity 0.25s ease;
     }
 
-    .sidebar-tab:hover {
+    .hamburger.at-top {
         opacity: 1;
+    }
+
+    .hamburger:hover,
+    .hamburger:focus-visible {
+        opacity: 1;
+    }
+
+    .hamburger span {
+        width: 20px;
+        height: 2px;
+        background: var(--text);
+        transition: all 0.2s;
+        display: block;
+    }
+
+    .sidebar-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.3);
+        z-index: 199;
+    }
+
+    .sidebar-backdrop.visible {
+        display: block;
     }
 }
 


### PR DESCRIPTION
## Summary
- Replaces the sidebar arrow tab (▶) with a hamburger menu on narrow desktops (769-1100px)
- Hamburger uses the same behavior as mobile: fully visible at top, fades when scrolled, click to open sidebar with backdrop
- Applied across all three pages: main site, For Researchers, For Machines
- Removed now-unused sidebar-tab JS handlers

## Test plan
- [ ] At 769-1100px width, verify hamburger appears (no arrow tab)
- [ ] At top of page, hamburger is fully visible; scrolled down, it fades
- [ ] Click hamburger to open sidebar with backdrop overlay
- [ ] Click backdrop or a sidebar link to close
- [ ] At >1100px, sidebar still shows normally (no hamburger, no arrow)
- [ ] At ≤768px, mobile hamburger still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)