### PR TITLE
Add spacing between divergence rail and arrows

### DIFF
--- a/docs/for-researchers/index.html
+++ b/docs/for-researchers/index.html
@@ -600,7 +600,7 @@
             display: flex;
             flex-direction: column;
             align-items: center;
-            gap: 0;
+            gap: 7px;
             user-select: none;
         }
         .dr-arrow {


### PR DESCRIPTION
## Summary
- Add 7px gap between the colored stack and the up/down arrow buttons in the divergence rail

🤖 Generated with [Claude Code](https://claude.com/claude-code)