### PR TITLE
Filter Rating History by max per-model rating count

### DIFF
--- a/bot/build_api.py
+++ b/bot/build_api.py
@@ -470,6 +470,13 @@ def build_consensus(generated_at: str) -> dict:
 
         write_json(CONSENSUS_API_DIR / f"{slug}.json", consensus_api)
 
+        # ── Max per-model rating count (how many rounds the busiest model rated) ──
+        model_round_counts = {}
+        for r in rounds:
+            for model_key in r.get("ratings", {}):
+                model_round_counts[model_key] = model_round_counts.get(model_key, 0) + 1
+        max_model_ratings = max(model_round_counts.values()) if model_round_counts else 0
+
         # ── Index entry ──
         entry = {
             "slug": slug,
@@ -477,6 +484,7 @@ def build_consensus(generated_at: str) -> dict:
             "score": combined["mean"] if combined else None,
             "agreement": combined["agreement"] if combined else None,
             "n_ratings": combined["n_total"] if combined else 0,
+            "max_model_ratings": max_model_ratings,
         }
         if scheduled:
             entry["scheduled_mean"] = scheduled["mean"]

--- a/docs/for-researchers/index.html
+++ b/docs/for-researchers/index.html
@@ -1703,7 +1703,7 @@
                         one model's recognition score (1&ndash;7) over time.
                     </p>
                     <div class="ds-controls">
-                        <label for="rating-history-min">Min ratings:</label>
+                        <label for="rating-history-min">Min per-model ratings:</label>
                         <select id="rating-history-min" class="ds-select">
                             <option value="2">2+</option>
                             <option value="3">3+</option>
@@ -3305,7 +3305,7 @@
         var minEl = document.getElementById('rating-history-min');
         var modelColors = ['#2563eb', '#059669', '#7c3aed', '#dc2626', '#d97706', '#0891b2', '#be185d', '#4f46e5', '#0d9488', '#c026d3'];
         var cache = {};
-        var allTerms = []; // [{slug, name, n_ratings}]
+        var allTerms = []; // [{slug, name, max_model_ratings}]
 
         // Populate term dropdown from consensus.json
         fetch(API + '/consensus.json')
@@ -3313,7 +3313,7 @@
             .then(function(data) {
                 if (!data || !data.terms) return;
                 allTerms = data.terms.map(function(t) {
-                    return { slug: t.slug, name: t.name || t.slug, n_ratings: t.n_ratings || 0 };
+                    return { slug: t.slug, name: t.name || t.slug, max_model_ratings: t.max_model_ratings || 0 };
                 }).sort(function(a, b) {
                     return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
                 });
@@ -3325,18 +3325,18 @@
 
         function populateTermSelect() {
             var min = parseInt(minEl.value, 10) || 2;
-            var filtered = allTerms.filter(function(t) { return t.n_ratings >= min; });
+            var filtered = allTerms.filter(function(t) { return t.max_model_ratings >= min; });
             var prevSlug = selectEl.value;
             var html = '';
             var foundPrev = false;
             for (var i = 0; i < filtered.length; i++) {
                 var t = filtered[i];
-                var label = escHtml(t.name) + ' (' + t.n_ratings + ' ratings)';
+                var label = escHtml(t.name) + ' (max ' + t.max_model_ratings + ' by one model)';
                 if (t.slug === prevSlug) foundPrev = true;
                 html += '<option value="' + escHtml(t.slug) + '">' + label + '</option>';
             }
             if (filtered.length === 0) {
-                html = '<option value="">No terms with ' + min + '+ ratings</option>';
+                html = '<option value="">No terms with ' + min + '+ per-model ratings</option>';
             }
             selectEl.innerHTML = html;
             if (foundPrev) {


### PR DESCRIPTION
## Summary
- Adds `max_model_ratings` field to `consensus.json` via `build_api.py` — the highest number of rounds any single model rated a given term
- Updates the Rating History "Min per-model ratings" filter to use this field instead of total `n_ratings`
- This lets researchers find terms where at least one model has rated repeatedly, which is what matters for studying rating stability over time

## Changes
- `bot/build_api.py`: Compute per-model round counts and add `max_model_ratings` to consensus index entries
- `docs/for-researchers/index.html`: Filter/label updated to use `max_model_ratings`

## Test plan
- [ ] Run `build_api.py` and verify `consensus.json` entries include `max_model_ratings`
- [ ] Verify the dropdown filters terms correctly (e.g., "10+" should only show terms where one model rated 10+ times)
- [ ] Verify the option labels show "max X by one model"

🤖 Generated with [Claude Code](https://claude.com/claude-code)