### PR TITLE
Update justification toggle to say 'latest justification'

### DIFF
--- a/docs/for-researchers/index.html
+++ b/docs/for-researchers/index.html
@@ -2241,7 +2241,7 @@
                     }
 
                     if (justification) {
-                        h += '<button class="te-justification-toggle" data-target="' + rowId + '">show justification</button>';
+                        h += '<button class="te-justification-toggle" data-target="' + rowId + '">show latest justification</button>';
                     }
                     h += '</div>';
 
@@ -2269,7 +2269,7 @@
                     if (target) {
                         var isOpen = target.classList.contains('open');
                         target.classList.toggle('open');
-                        this.textContent = isOpen ? 'show justification' : 'hide justification';
+                        this.textContent = isOpen ? 'show latest justification' : 'hide latest justification';
                     }
                 });
             }


### PR DESCRIPTION
## Summary
- Changes Term Explorer's "show justification" / "hide justification" toggle text to "show latest justification" / "hide latest justification"
- The displayed justification is already the latest one (build_api.py uses the most recent round per model)

## Test plan
- [ ] Open Term Explorer, expand a term with per-model ratings
- [ ] Verify button reads "show latest justification"
- [ ] Click it, verify it toggles to "hide latest justification" and displays the justification text

🤖 Generated with [Claude Code](https://claude.com/claude-code)