### PR TITLE
Add 'by at least N models' filter to Rating History

### DIFF
--- a/bot/build_api.py
+++ b/bot/build_api.py
@@ -470,12 +470,12 @@ def build_consensus(generated_at: str) -> dict:
 
         write_json(CONSENSUS_API_DIR / f"{slug}.json", consensus_api)
 
-        # ── Max per-model rating count (how many rounds the busiest model rated) ──
+        # ── Per-model rating counts (sorted descending) ──
         model_round_counts = {}
         for r in rounds:
             for model_key in r.get("ratings", {}):
                 model_round_counts[model_key] = model_round_counts.get(model_key, 0) + 1
-        max_model_ratings = max(model_round_counts.values()) if model_round_counts else 0
+        rating_counts_desc = sorted(model_round_counts.values(), reverse=True)
 
         # ── Index entry ──
         entry = {
@@ -484,7 +484,7 @@ def build_consensus(generated_at: str) -> dict:
             "score": combined["mean"] if combined else None,
             "agreement": combined["agreement"] if combined else None,
             "n_ratings": combined["n_total"] if combined else 0,
-            "max_model_ratings": max_model_ratings,
+            "model_rating_counts": rating_counts_desc,
         }
         if scheduled:
             entry["scheduled_mean"] = scheduled["mean"]

--- a/docs/for-researchers/index.html
+++ b/docs/for-researchers/index.html
@@ -1703,7 +1703,7 @@
                         one model's recognition score (1&ndash;7) over time.
                     </p>
                     <div class="ds-controls">
-                        <label for="rating-history-min">Min per-model ratings:</label>
+                        <label for="rating-history-min">Min ratings per model:</label>
                         <select id="rating-history-min" class="ds-select">
                             <option value="2">2+</option>
                             <option value="3">3+</option>
@@ -1711,6 +1711,14 @@
                             <option value="5">5+</option>
                             <option value="10">10+</option>
                             <option value="20">20+</option>
+                        </select>
+                        <label for="rating-history-min-models">By at least:</label>
+                        <select id="rating-history-min-models" class="ds-select">
+                            <option value="1">1 model</option>
+                            <option value="2">2 models</option>
+                            <option value="3" selected>3 models</option>
+                            <option value="4">4 models</option>
+                            <option value="5">5 models</option>
                         </select>
                         <label for="rating-history-select">Term:</label>
                         <select id="rating-history-select" class="ds-select">
@@ -3303,9 +3311,10 @@
         var legendEl = document.getElementById('rating-history-legend');
         var selectEl = document.getElementById('rating-history-select');
         var minEl = document.getElementById('rating-history-min');
+        var minModelsEl = document.getElementById('rating-history-min-models');
         var modelColors = ['#2563eb', '#059669', '#7c3aed', '#dc2626', '#d97706', '#0891b2', '#be185d', '#4f46e5', '#0d9488', '#c026d3'];
         var cache = {};
-        var allTerms = []; // [{slug, name, max_model_ratings}]
+        var allTerms = []; // [{slug, name, counts: [desc sorted per-model counts]}]
 
         // Populate term dropdown from consensus.json
         fetch(API + '/consensus.json')
@@ -3313,7 +3322,7 @@
             .then(function(data) {
                 if (!data || !data.terms) return;
                 allTerms = data.terms.map(function(t) {
-                    return { slug: t.slug, name: t.name || t.slug, max_model_ratings: t.max_model_ratings || 0 };
+                    return { slug: t.slug, name: t.name || t.slug, counts: t.model_rating_counts || [] };
                 }).sort(function(a, b) {
                     return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
                 });
@@ -3323,20 +3332,32 @@
                 vizEl.innerHTML = '<p style="color:var(--text-muted);">Could not load term list.</p>';
             });
 
+        function modelsAboveThreshold(counts, minRatings) {
+            var n = 0;
+            for (var i = 0; i < counts.length; i++) {
+                if (counts[i] >= minRatings) n++;
+            }
+            return n;
+        }
+
         function populateTermSelect() {
-            var min = parseInt(minEl.value, 10) || 2;
-            var filtered = allTerms.filter(function(t) { return t.max_model_ratings >= min; });
+            var minRatings = parseInt(minEl.value, 10) || 2;
+            var minModels = parseInt(minModelsEl.value, 10) || 1;
+            var filtered = allTerms.filter(function(t) {
+                return modelsAboveThreshold(t.counts, minRatings) >= minModels;
+            });
             var prevSlug = selectEl.value;
             var html = '';
             var foundPrev = false;
             for (var i = 0; i < filtered.length; i++) {
                 var t = filtered[i];
-                var label = escHtml(t.name) + ' (max ' + t.max_model_ratings + ' by one model)';
+                var nQualifying = modelsAboveThreshold(t.counts, minRatings);
+                var label = escHtml(t.name) + ' (' + nQualifying + ' model' + (nQualifying !== 1 ? 's' : '') + ' w/ ' + minRatings + '+)';
                 if (t.slug === prevSlug) foundPrev = true;
                 html += '<option value="' + escHtml(t.slug) + '">' + label + '</option>';
             }
             if (filtered.length === 0) {
-                html = '<option value="">No terms with ' + min + '+ per-model ratings</option>';
+                html = '<option value="">No terms match this filter</option>';
             }
             selectEl.innerHTML = html;
             if (foundPrev) {
@@ -3351,6 +3372,7 @@
         }
 
         minEl.addEventListener('change', populateTermSelect);
+        minModelsEl.addEventListener('change', populateTermSelect);
 
         function renderChart(slug) {
             vizEl.innerHTML = '<p style="color:var(--text-muted); font-style:italic;">Loading...</p>';


### PR DESCRIPTION
## Summary
- Replaces `max_model_ratings` with `model_rating_counts` in `consensus.json` — a sorted descending array of per-model round counts (e.g. `[11, 11, 11, 1, 1, 1, 1]`)
- Adds a second filter dropdown "By at least: N models" so researchers can require multiple models to meet the per-model rating threshold
- Example: "Min 5+ ratings per model, by at least 3 models" shows only terms where 3+ models each rated 5+ times
- Option labels show qualifying model count (e.g. "Context Amnesia (3 models w/ 5+)")

## Test plan
- [ ] Run `build_api.py` and verify `consensus.json` entries have `model_rating_counts` arrays
- [ ] Set "Min ratings per model: 2+" / "By at least: 1 model" — should show most terms
- [ ] Set "Min ratings per model: 10+" / "By at least: 3 models" — should narrow significantly
- [ ] Verify changing either filter re-populates the term list and preserves selection when possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)