### PR TITLE
Center graph and increase node/label sizes

### DIFF
--- a/docs/for-researchers/index.html
+++ b/docs/for-researchers/index.html
@@ -2381,13 +2381,12 @@
                 return;
             }
 
-            var w = 800, h = 560;
-            var cx = w / 2, cy = h / 2 - 10;
-            var dim = Math.min(w, h);
+            var w = 800, h = 600;
+            var cx = w / 2, cy = h / 2;
 
-            // Radii for each ring
-            var ringRadii = [0, dim * 0.22, dim * 0.38, dim * 0.48];
-            var nodeRadii = [20, 10, 8, 6];
+            // Radii for each ring — use width as base so nodes spread horizontally
+            var ringRadii = [0, 130, 230, 280];
+            var nodeRadii = [22, 14, 11, 9];
 
             // Group slugs by ring
             var ringGroups = [[], [], [], []];
@@ -2464,9 +2463,9 @@
                 g.appendChild(circle);
 
                 var label = svgEl('text', {
-                    x: p.x, y: p.y + r + 14,
+                    x: p.x, y: p.y + r + 15,
                     'text-anchor': 'middle',
-                    'font-size': isCenter ? '11' : '10',
+                    'font-size': isCenter ? '13' : '11',
                     fill: 'var(--text-secondary)',
                     'font-weight': isCenter ? 'bold' : 'normal'
                 });


### PR DESCRIPTION
## Summary
- **Centered graph**: ViewBox increased to 800×600 with center at true midpoint (400, 300) — no more off-center offset
- **Larger nodes**: Radii bumped from 20/10/8/6 → 22/14/11/9 for better visibility
- **Larger labels**: Font sizes increased from 11/10 → 13/11px
- **Fixed ring radii**: Switched from percentage-based (caused bottom clipping) to fixed values (130/230/280px) that fit comfortably within the viewBox

## Test plan
- [ ] Graph appears centered in the SVG canvas
- [ ] Nodes are visibly larger and easier to interact with
- [ ] Labels are readable at all degrees
- [ ] Bottom-most labels don't clip

🤖 Generated with [Claude Code](https://claude.com/claude-code)