### PR TITLE
Fix Rating History filter: add 'each', allow y=1

### DIFF
--- a/docs/for-researchers/index.html
+++ b/docs/for-researchers/index.html
@@ -1713,6 +1713,7 @@
                         </select>
                         <span style="font-size:0.9rem;color:var(--text-secondary);white-space:nowrap;">model(s) with at least</span>
                         <select id="rating-history-min" class="ds-select">
+                            <option value="1">1</option>
                             <option value="2">2</option>
                             <option value="3">3</option>
                             <option value="4">4</option>
@@ -1720,7 +1721,7 @@
                             <option value="7">7</option>
                             <option value="10">10</option>
                         </select>
-                        <span style="font-size:0.9rem;color:var(--text-secondary);white-space:nowrap;">ratings:</span>
+                        <span style="font-size:0.9rem;color:var(--text-secondary);white-space:nowrap;">rating(s) each:</span>
                         <select id="rating-history-select" class="ds-select">
                             <option value="">Loading terms...</option>
                         </select>


### PR DESCRIPTION
## Summary
- Text now reads: "At least [X] model(s) with at least [Y] rating(s) **each**:"
- Added `1` as an option for the ratings dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)