### PR TITLE
Refine Library Health dashboard: inline, family grouping, interactive charts

### DIFF
--- a/docs/for-researchers/index.html
+++ b/docs/for-researchers/index.html
@@ -734,35 +734,6 @@
         }
 
         /* Library Health dashboard */
-        .lh-trigger {
-            background: var(--bg-secondary);
-            border: 1px solid var(--border);
-            border-radius: var(--radius);
-            padding: 1.25rem;
-            margin-bottom: 1.5rem;
-            cursor: pointer;
-            transition: border-color 0.2s, box-shadow 0.2s;
-        }
-        .lh-trigger:hover, .lh-trigger:focus-visible {
-            border-color: var(--primary);
-            box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
-            outline: none;
-        }
-        .lh-trigger h4 { margin: 0 0 0.5rem 0; font-size: 1.1rem; }
-        .lh-trigger-stats {
-            display: flex;
-            gap: 0.75rem;
-            flex-wrap: wrap;
-            margin-bottom: 0.5rem;
-        }
-        .lh-trigger-pill {
-            background: var(--bg-tertiary);
-            padding: 0.2rem 0.6rem;
-            border-radius: 4px;
-            font-size: 0.85rem;
-            color: var(--text-secondary);
-        }
-        .lh-modal { max-width: 800px; }
         .lh-tabs {
             display: flex;
             gap: 0;
@@ -833,6 +804,31 @@
             border-radius: 3px;
             flex-shrink: 0;
         }
+        .lh-legend-toggle {
+            cursor: pointer;
+            user-select: none;
+        }
+        .lh-legend-toggle::before {
+            content: '\25B6';
+            display: inline-block;
+            font-size: 0.6rem;
+            margin-right: 0.3rem;
+            transition: transform 0.2s;
+        }
+        .lh-legend-item.expanded .lh-legend-toggle::before {
+            transform: rotate(90deg);
+        }
+        .lh-legend-sub {
+            display: none;
+            padding-left: 1.5rem;
+            font-size: 0.75rem;
+            color: var(--text-muted);
+            line-height: 1.6;
+        }
+        .lh-legend-item.expanded .lh-legend-sub {
+            display: block;
+        }
+        .lh-legend-item.highlight { font-weight: bold; }
         .lh-section-title {
             font-size: 0.9rem;
             font-weight: 600;
@@ -1498,10 +1494,17 @@
                     High-level dashboard of dictionary health &mdash; term counts, model contributions,
                     rating distributions, and agreement patterns, all computed from live API data.
                 </p>
-                <div class="lh-trigger" id="lh-trigger" role="button" tabindex="0">
-                    <h4>Library Health Dashboard</h4>
-                    <div class="lh-trigger-stats" id="lh-trigger-stats"></div>
-                    <p style="color: var(--text-muted); font-size: 0.85rem; margin: 0;">Click to explore full dashboard &rarr;</p>
+                <div id="lh-dashboard">
+                    <div class="lh-tabs">
+                        <button class="lh-tab active" data-tab="overview">Overview</button>
+                        <button class="lh-tab" data-tab="ratings">Ratings</button>
+                    </div>
+                    <div class="lh-tab-panel active" data-tab="overview" id="lh-panel-overview">
+                        <p style="color: var(--text-muted); font-style: italic;">Loading...</p>
+                    </div>
+                    <div class="lh-tab-panel" data-tab="ratings" id="lh-panel-ratings">
+                        <p style="color: var(--text-muted); font-style: italic;">Loading...</p>
+                    </div>
                 </div>
 
                 <h3>Model Comparison</h3>
@@ -1948,24 +1951,6 @@
         </div>
     </div>
 
-    <!-- Library Health modal -->
-    <div class="modal-overlay" id="lh-modal-overlay">
-        <div class="modal lh-modal">
-            <button class="modal-close" id="lh-modal-close">&times;</button>
-            <h2>Library Health Dashboard</h2>
-            <div class="lh-tabs">
-                <button class="lh-tab active" data-tab="overview">Overview</button>
-                <button class="lh-tab" data-tab="ratings">Ratings</button>
-            </div>
-            <div class="lh-tab-panel active" data-tab="overview" id="lh-panel-overview">
-                <p style="color: var(--text-muted); font-style: italic;">Loading...</p>
-            </div>
-            <div class="lh-tab-panel" data-tab="ratings" id="lh-panel-ratings">
-                <p style="color: var(--text-muted); font-style: italic;">Loading...</p>
-            </div>
-        </div>
-    </div>
-
     <script>
     // Utility: escape HTML
     function escHtml(s) {
@@ -2079,18 +2064,26 @@
     (function() {
         var PIE_COLORS = ['#2563eb', '#059669', '#7c3aed', '#dc2626', '#d97706', '#0891b2', '#be185d', '#4338ca'];
         var AGREEMENT_COLORS = { high: '#22c55e', moderate: '#f59e0b', low: '#f97316', contested: '#ef4444' };
-        var INTEREST_COLORS = { hot: '#ef4444', warm: '#f59e0b', mild: '#2563eb', cool: '#0891b2', quiet: '#94a3b8' };
+        var DEPTH_COLORS = ['#bfdbfe', '#93c5fd', '#60a5fa', '#3b82f6', '#1d4ed8'];
 
         var lhData = {};
         var overviewRendered = false;
         var ratingsRendered = false;
 
-        var trigger = document.getElementById('lh-trigger');
-        var triggerStats = document.getElementById('lh-trigger-stats');
-        var overlay = document.getElementById('lh-modal-overlay');
-        var closeBtn = document.getElementById('lh-modal-close');
-        var tabs = document.querySelectorAll('.lh-tab');
-        var panels = document.querySelectorAll('.lh-tab-panel');
+        var tabs = document.querySelectorAll('#lh-dashboard .lh-tab');
+        var panels = document.querySelectorAll('#lh-dashboard .lh-tab-panel');
+
+        function getFamily(name) {
+            var n = (name || '').toLowerCase();
+            if (n.indexOf('claude') !== -1) return 'Claude';
+            if (n.indexOf('gpt') !== -1 || n.indexOf('chatgpt') !== -1) return 'GPT';
+            if (n.indexOf('gemini') !== -1) return 'Gemini';
+            if (n.indexOf('deepseek') !== -1) return 'DeepSeek';
+            if (n.indexOf('grok') !== -1) return 'Grok';
+            if (n.indexOf('mistral') !== -1) return 'Mistral';
+            if (n.indexOf('step') !== -1) return 'Step';
+            return 'Other';
+        }
 
         // Fetch all endpoints in parallel
         Promise.all([
@@ -2098,7 +2091,6 @@
             fetch(API + '/terms.json').then(function(r) { return r.json(); }).catch(function() { return null; }),
             fetch(API + '/models.json').then(function(r) { return r.json(); }).catch(function() { return null; }),
             fetch(API + '/consensus.json').then(function(r) { return r.json(); }).catch(function() { return null; }),
-            fetch(API + '/interest.json').then(function(r) { return r.json(); }).catch(function() { return null; }),
             fetch(API + '/tags.json').then(function(r) { return r.json(); }).catch(function() { return null; }),
             fetch(API + '/changelog.json').then(function(r) { return r.json(); }).catch(function() { return null; })
         ]).then(function(results) {
@@ -2106,42 +2098,48 @@
             lhData.terms = results[1];
             lhData.models = results[2];
             lhData.consensus = results[3];
-            lhData.interest = results[4];
-            lhData.tags = results[5];
-            lhData.changelog = results[6];
-            populateTrigger();
+            lhData.tags = results[4];
+            lhData.changelog = results[5];
+            renderOverview();
         });
-
-        function populateTrigger() {
-            var termCount = lhData.meta && lhData.meta.total_terms ? lhData.meta.total_terms : (lhData.terms && lhData.terms.terms ? lhData.terms.terms.length : '?');
-            var ratingCount = 0;
-            if (lhData.models && lhData.models.models) {
-                var mNames = Object.keys(lhData.models.models);
-                for (var i = 0; i < mNames.length; i++) {
-                    ratingCount += lhData.models.models[mNames[i]].total_ratings || 0;
-                }
-            }
-            var modelCount = lhData.models && lhData.models.models ? Object.keys(lhData.models.models).length : '?';
-            triggerStats.innerHTML =
-                '<span class="lh-trigger-pill">Terms: <strong>' + termCount + '</strong></span>' +
-                '<span class="lh-trigger-pill">Ratings: <strong>' + ratingCount + '</strong></span>' +
-                '<span class="lh-trigger-pill">Models: <strong>' + modelCount + '</strong></span>';
-        }
 
         // Normalize contributor name from contributed_by field
         function normalizeContributor(raw) {
             if (!raw) return 'Unknown';
             var s = String(raw).trim();
-            // Handle "Model Name (via ...)" or "Model Name via ..."
             s = s.replace(/\s*\(via[^)]*\)/i, '').replace(/\s+via\s+.*/i, '');
-            // Handle "Model Name - ..." suffixes
             s = s.replace(/\s*-\s*\d{4}.*/, '');
             return s || 'Unknown';
         }
 
-        // Draw a pie chart as inline SVG
+        // Group items by model family, returns {families: [{label, value, color, members: [{name, count}]}], total}
+        function groupByFamily(nameCountMap) {
+            var familyMap = {};
+            var names = Object.keys(nameCountMap);
+            for (var i = 0; i < names.length; i++) {
+                var fam = getFamily(names[i]);
+                if (!familyMap[fam]) familyMap[fam] = { total: 0, members: [] };
+                familyMap[fam].total += nameCountMap[names[i]];
+                familyMap[fam].members.push({ name: names[i], count: nameCountMap[names[i]] });
+            }
+            var famNames = Object.keys(familyMap).sort(function(a, b) { return familyMap[b].total - familyMap[a].total; });
+            var data = [];
+            var total = 0;
+            for (var i = 0; i < famNames.length; i++) {
+                familyMap[famNames[i]].members.sort(function(a, b) { return b.count - a.count; });
+                data.push({
+                    label: famNames[i],
+                    value: familyMap[famNames[i]].total,
+                    color: PIE_COLORS[i % PIE_COLORS.length],
+                    members: familyMap[famNames[i]].members
+                });
+                total += familyMap[famNames[i]].total;
+            }
+            return { data: data, total: total };
+        }
+
+        // Draw a pie chart as inline SVG with data-lh-idx attributes
         function drawPieChart(data, size) {
-            // data: [{label, value, color}]
             var total = 0;
             for (var i = 0; i < data.length; i++) total += data[i].value;
             if (total === 0) return '<p style="color:var(--text-muted);">No data</p>';
@@ -2150,7 +2148,7 @@
             var svg = '<svg width="' + size + '" height="' + size + '" viewBox="0 0 ' + size + ' ' + size + '" xmlns="http://www.w3.org/2000/svg">';
 
             if (data.length === 1) {
-                svg += '<circle cx="' + cx + '" cy="' + cy + '" r="' + r + '" fill="' + data[0].color + '">';
+                svg += '<circle cx="' + cx + '" cy="' + cy + '" r="' + r + '" fill="' + data[0].color + '" data-lh-idx="0">';
                 svg += '<title>' + escHtml(data[0].label) + ': ' + data[0].value + ' (' + (100).toFixed(1) + '%)</title>';
                 svg += '</circle>';
                 svg += '</svg>';
@@ -2166,7 +2164,7 @@
                 var y2 = cy + r * Math.sin(angle + slice);
                 var largeArc = slice > Math.PI ? 1 : 0;
                 var pct = (data[i].value / total * 100).toFixed(1);
-                svg += '<path d="M' + cx + ',' + cy + ' L' + x1.toFixed(2) + ',' + y1.toFixed(2) + ' A' + r + ',' + r + ' 0 ' + largeArc + ',1 ' + x2.toFixed(2) + ',' + y2.toFixed(2) + ' Z" fill="' + data[i].color + '">';
+                svg += '<path d="M' + cx + ',' + cy + ' L' + x1.toFixed(2) + ',' + y1.toFixed(2) + ' A' + r + ',' + r + ' 0 ' + largeArc + ',1 ' + x2.toFixed(2) + ',' + y2.toFixed(2) + ' Z" fill="' + data[i].color + '" data-lh-idx="' + i + '">';
                 svg += '<title>' + escHtml(data[i].label) + ': ' + data[i].value + ' (' + pct + '%)</title>';
                 svg += '</path>';
                 angle += slice;
@@ -2175,21 +2173,73 @@
             return svg;
         }
 
-        function buildLegend(data, total) {
+        function buildFamilyLegend(data, total) {
             var h = '<div class="lh-legend">';
             for (var i = 0; i < data.length; i++) {
                 var pct = total > 0 ? (data[i].value / total * 100).toFixed(1) : '0.0';
-                h += '<div class="lh-legend-item">';
+                h += '<div class="lh-legend-item" data-lh-idx="' + i + '">';
                 h += '<span class="lh-legend-swatch" style="background:' + data[i].color + '"></span>';
-                h += '<span>' + escHtml(data[i].label) + ' &mdash; ' + data[i].value + ' (' + pct + '%)</span>';
+                if (data[i].members && data[i].members.length > 1) {
+                    h += '<span class="lh-legend-toggle">' + escHtml(data[i].label) + ' &mdash; ' + data[i].value + ' (' + pct + '%)</span>';
+                    h += '<div class="lh-legend-sub">';
+                    for (var j = 0; j < data[i].members.length; j++) {
+                        h += '<div>' + escHtml(data[i].members[j].name) + ': ' + data[i].members[j].count + '</div>';
+                    }
+                    h += '</div>';
+                } else {
+                    var displayName = data[i].members && data[i].members.length === 1 ? data[i].members[0].name : data[i].label;
+                    h += '<span>' + escHtml(displayName) + ' &mdash; ' + data[i].value + ' (' + pct + '%)</span>';
+                }
                 h += '</div>';
             }
             h += '</div>';
             return h;
         }
 
+        function wireChartHover(container) {
+            var paths = container.querySelectorAll('[data-lh-idx]');
+            var svgPaths = container.querySelectorAll('svg [data-lh-idx]');
+            var legendItems = container.querySelectorAll('.lh-legend-item[data-lh-idx]');
+
+            function highlightIdx(idx) {
+                for (var i = 0; i < svgPaths.length; i++) {
+                    svgPaths[i].style.opacity = svgPaths[i].getAttribute('data-lh-idx') === idx ? '1' : '0.4';
+                }
+                for (var i = 0; i < legendItems.length; i++) {
+                    if (legendItems[i].getAttribute('data-lh-idx') === idx) {
+                        legendItems[i].classList.add('highlight');
+                    } else {
+                        legendItems[i].classList.remove('highlight');
+                    }
+                }
+            }
+
+            function clearHighlight() {
+                for (var i = 0; i < svgPaths.length; i++) svgPaths[i].style.opacity = '1';
+                for (var i = 0; i < legendItems.length; i++) legendItems[i].classList.remove('highlight');
+            }
+
+            for (var i = 0; i < svgPaths.length; i++) {
+                svgPaths[i].addEventListener('mouseenter', function() { highlightIdx(this.getAttribute('data-lh-idx')); });
+                svgPaths[i].addEventListener('mouseleave', clearHighlight);
+            }
+            for (var i = 0; i < legendItems.length; i++) {
+                legendItems[i].addEventListener('mouseenter', function() { highlightIdx(this.getAttribute('data-lh-idx')); });
+                legendItems[i].addEventListener('mouseleave', clearHighlight);
+            }
+
+            // Toggle expand on family legend click
+            var toggles = container.querySelectorAll('.lh-legend-toggle');
+            for (var i = 0; i < toggles.length; i++) {
+                toggles[i].addEventListener('click', function(e) {
+                    e.stopPropagation();
+                    var item = this.closest('.lh-legend-item');
+                    if (item) item.classList.toggle('expanded');
+                });
+            }
+        }
+
         function buildDistBars(rows) {
-            // rows: [{label, count, total, color}]
             var h = '';
             for (var i = 0; i < rows.length; i++) {
                 var pct = rows[i].total > 0 ? (rows[i].count / rows[i].total * 100) : 0;
@@ -2265,44 +2315,47 @@
                 ]);
             }
 
-            // Interest tier distribution
-            if (lhData.interest) {
-                var tierSummary = lhData.interest.tier_summary;
-                if (tierSummary) {
-                    var iTotal = (tierSummary.hot || 0) + (tierSummary.warm || 0) + (tierSummary.mild || 0) + (tierSummary.cool || 0) + (tierSummary.quiet || 0);
-                    h += '<div class="lh-section-title" style="margin-top:1.25rem;">Interest Tiers</div>';
-                    h += buildDistBars([
-                        { label: 'Hot', count: tierSummary.hot || 0, total: iTotal, color: INTEREST_COLORS.hot },
-                        { label: 'Warm', count: tierSummary.warm || 0, total: iTotal, color: INTEREST_COLORS.warm },
-                        { label: 'Mild', count: tierSummary.mild || 0, total: iTotal, color: INTEREST_COLORS.mild },
-                        { label: 'Cool', count: tierSummary.cool || 0, total: iTotal, color: INTEREST_COLORS.cool },
-                        { label: 'Quiet', count: tierSummary.quiet || 0, total: iTotal, color: INTEREST_COLORS.quiet }
-                    ]);
+            // Score distribution (moved from Ratings)
+            if (lhData.consensus && lhData.consensus.terms) {
+                var scoreBuckets = [0, 0, 0, 0, 0, 0, 0];
+                var scoredCount = 0;
+                for (var i = 0; i < lhData.consensus.terms.length; i++) {
+                    var sc = lhData.consensus.terms[i].score;
+                    if (sc !== undefined && sc !== null) {
+                        var bucket = Math.round(sc) - 1;
+                        if (bucket >= 0 && bucket < 7) {
+                            scoreBuckets[bucket]++;
+                            scoredCount++;
+                        }
+                    }
                 }
+                var scoreColors = ['#ef4444', '#f97316', '#f59e0b', '#eab308', '#84cc16', '#22c55e', '#059669'];
+                var scoreRows = [];
+                for (var i = 0; i < 7; i++) {
+                    scoreRows.push({ label: 'Score ' + (i + 1), count: scoreBuckets[i], total: scoredCount, color: scoreColors[i] });
+                }
+                h += '<div class="lh-section-title" style="margin-top:1.25rem;">Score Distribution</div>';
+                h += buildDistBars(scoreRows);
             }
 
-            // Term contributions pie chart
+            // Term contributions pie chart — grouped by family
             if (lhData.terms && lhData.terms.terms) {
                 var contribCounts = {};
                 for (var i = 0; i < lhData.terms.terms.length; i++) {
                     var contributor = normalizeContributor(lhData.terms.terms[i].contributed_by);
                     contribCounts[contributor] = (contribCounts[contributor] || 0) + 1;
                 }
-                var contribData = [];
-                var contribNames = Object.keys(contribCounts).sort(function(a, b) { return contribCounts[b] - contribCounts[a]; });
-                var contribTotal = 0;
-                for (var i = 0; i < contribNames.length; i++) {
-                    contribData.push({ label: contribNames[i], value: contribCounts[contribNames[i]], color: PIE_COLORS[i % PIE_COLORS.length] });
-                    contribTotal += contribCounts[contribNames[i]];
-                }
-                h += '<div class="lh-section-title" style="margin-top:1.5rem;">Term Contributions by Model</div>';
-                h += '<div class="lh-chart-section">';
-                h += drawPieChart(contribData, 180);
-                h += buildLegend(contribData, contribTotal);
+                var grouped = groupByFamily(contribCounts);
+                h += '<div class="lh-section-title" style="margin-top:1.5rem;">Term Contributions by Model Family</div>';
+                h += '<div class="lh-chart-section" id="lh-overview-chart">';
+                h += drawPieChart(grouped.data, 180);
+                h += buildFamilyLegend(grouped.data, grouped.total);
                 h += '</div>';
             }
 
             panel.innerHTML = h;
+            var chartEl = document.getElementById('lh-overview-chart');
+            if (chartEl) wireChartHover(chartEl);
         }
 
         function renderRatings() {
@@ -2324,7 +2377,6 @@
                 }
             }
 
-            // Dictionary mean and std dev range
             var dictMean = 0;
             var dictStdRange = '';
             if (allMeans.length > 0) {
@@ -2348,74 +2400,49 @@
             h += '<div class="lh-stat-box"><div class="lh-stat-value">' + dictStdRange + '</div><div class="lh-stat-label">Model Mean Range</div></div>';
             h += '</div>';
 
-            // Score distribution
+            // Rating depth distribution
             if (lhData.consensus && lhData.consensus.terms) {
-                var scoreBuckets = [0, 0, 0, 0, 0, 0, 0]; // indices 0-6 for scores 1-7
-                var scoredCount = 0;
+                var depthBuckets = [0, 0, 0, 0, 0]; // 1-7, 8-14, 15-21, 22-28, 29+
+                var depthTotal = 0;
                 for (var i = 0; i < lhData.consensus.terms.length; i++) {
-                    var sc = lhData.consensus.terms[i].score;
-                    if (sc !== undefined && sc !== null) {
-                        var bucket = Math.round(sc) - 1;
-                        if (bucket >= 0 && bucket < 7) {
-                            scoreBuckets[bucket]++;
-                            scoredCount++;
-                        }
+                    var nr = lhData.consensus.terms[i].n_ratings;
+                    if (nr !== undefined && nr !== null) {
+                        depthTotal++;
+                        if (nr <= 7) depthBuckets[0]++;
+                        else if (nr <= 14) depthBuckets[1]++;
+                        else if (nr <= 21) depthBuckets[2]++;
+                        else if (nr <= 28) depthBuckets[3]++;
+                        else depthBuckets[4]++;
                     }
                 }
-                var scoreColors = ['#ef4444', '#f97316', '#f59e0b', '#eab308', '#84cc16', '#22c55e', '#059669'];
-                var scoreRows = [];
-                for (var i = 0; i < 7; i++) {
-                    scoreRows.push({ label: 'Score ' + (i + 1), count: scoreBuckets[i], total: scoredCount, color: scoreColors[i] });
+                var depthLabels = ['1-7', '8-14', '15-21', '22-28', '29+'];
+                var depthRows = [];
+                for (var i = 0; i < 5; i++) {
+                    depthRows.push({ label: depthLabels[i] + ' ratings', count: depthBuckets[i], total: depthTotal, color: DEPTH_COLORS[i] });
                 }
-                h += '<div class="lh-section-title">Score Distribution</div>';
-                h += buildDistBars(scoreRows);
+                h += '<div class="lh-section-title">Rating Depth Distribution</div>';
+                h += buildDistBars(depthRows);
             }
 
-            // Rating contributions pie chart
+            // Rating contributions pie chart — grouped by family
             if (lhData.models && lhData.models.models) {
-                var ratingData = [];
-                var mNames = Object.keys(lhData.models.models).sort(function(a, b) {
-                    return (lhData.models.models[b].total_ratings || 0) - (lhData.models.models[a].total_ratings || 0);
-                });
-                var rTotal = 0;
+                var ratingCounts = {};
+                var mNames = Object.keys(lhData.models.models);
                 for (var i = 0; i < mNames.length; i++) {
-                    var tr = lhData.models.models[mNames[i]].total_ratings || 0;
-                    ratingData.push({ label: mNames[i], value: tr, color: PIE_COLORS[i % PIE_COLORS.length] });
-                    rTotal += tr;
+                    ratingCounts[mNames[i]] = lhData.models.models[mNames[i]].total_ratings || 0;
                 }
-                h += '<div class="lh-section-title" style="margin-top:1.5rem;">Rating Contributions by Model</div>';
-                h += '<div class="lh-chart-section">';
-                h += drawPieChart(ratingData, 180);
-                h += buildLegend(ratingData, rTotal);
+                var grouped = groupByFamily(ratingCounts);
+                h += '<div class="lh-section-title" style="margin-top:1.5rem;">Rating Contributions by Model Family</div>';
+                h += '<div class="lh-chart-section" id="lh-ratings-chart">';
+                h += drawPieChart(grouped.data, 180);
+                h += buildFamilyLegend(grouped.data, grouped.total);
                 h += '</div>';
             }
 
             panel.innerHTML = h;
+            var chartEl = document.getElementById('lh-ratings-chart');
+            if (chartEl) wireChartHover(chartEl);
         }
-
-        // Modal open/close
-        function openLhModal() {
-            overlay.classList.add('active');
-            document.body.style.overflow = 'hidden';
-            renderOverview();
-        }
-
-        function closeLhModal() {
-            overlay.classList.remove('active');
-            document.body.style.overflow = '';
-        }
-
-        trigger.addEventListener('click', openLhModal);
-        trigger.addEventListener('keydown', function(e) {
-            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openLhModal(); }
-        });
-        closeBtn.addEventListener('click', closeLhModal);
-        overlay.addEventListener('click', function(e) {
-            if (e.target === e.currentTarget) closeLhModal();
-        });
-        document.addEventListener('keydown', function(e) {
-            if (e.key === 'Escape' && overlay.classList.contains('active')) closeLhModal();
-        });
 
         // Tab switching
         for (var i = 0; i < tabs.length; i++) {
@@ -2424,7 +2451,7 @@
                 for (var j = 0; j < tabs.length; j++) tabs[j].classList.remove('active');
                 for (var j = 0; j < panels.length; j++) panels[j].classList.remove('active');
                 this.classList.add('active');
-                var targetPanel = document.querySelector('.lh-tab-panel[data-tab="' + target + '"]');
+                var targetPanel = document.querySelector('#lh-dashboard .lh-tab-panel[data-tab="' + target + '"]');
                 if (targetPanel) targetPanel.classList.add('active');
                 if (target === 'ratings') renderRatings();
             });


### PR DESCRIPTION
## Summary
- Display Library Health dashboard inline (no modal) so it renders on page load
- Remove interest tiers section from Overview
- Move score distribution bars to Overview tab; add rating depth distribution (by `n_ratings` buckets) to Ratings tab
- Group both pie charts by model family (Claude, GPT, Gemini, etc.) with expandable sub-model lists
- Add interactive hover highlighting between pie chart slices and legend items

## Test plan
- [ ] Page loads with Library Health rendered inline under Overview tab — no click required
- [ ] No interest tiers section visible
- [ ] Score distribution bars appear in Overview after agreement distribution
- [ ] Ratings tab shows rating depth distribution + family-grouped ratings pie
- [ ] Hovering a pie slice highlights the matching legend item; hovering a legend item highlights the pie slice
- [ ] Clicking a family name with multiple models expands sub-model list
- [ ] Existing term modal and other Data Samples sections unaffected
- [ ] Mobile responsive layout still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)