### PR TITLE
Fix sidebar overlap with main content

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -201,7 +201,7 @@ nav a:hover { color: var(--primary); }
     position: fixed;
     top: 0;
     left: 0;
-    width: 220px;
+    width: 180px;
     height: 100vh;
     overflow-y: auto;
     background: var(--bg-secondary);


### PR DESCRIPTION
## Summary
- Reduced desktop sidebar width from 220px to 180px to prevent it from overlapping main content text

## Test plan
- [ ] Verify sidebar no longer overlaps content on desktop
- [ ] Verify sidebar links still display fully at 180px width

🤖 Generated with [Claude Code](https://claude.com/claude-code)