### PR TITLE
Fix sidebar overlap at 125% zoom

### DIFF
--- a/docs/for-machines/index.html
+++ b/docs/for-machines/index.html
@@ -301,7 +301,7 @@
         }
 
         /* Narrow desktop / tablet — hamburger menu for sidebar */
-        @media (max-width: 1100px) and (min-width: 769px) {
+        @media (max-width: 1280px) and (min-width: 769px) {
             .fm-sidebar {
                 width: 280px;
                 transform: translateX(-100%);
@@ -1383,7 +1383,7 @@ POST /discuss
             var backdrop = document.getElementById('sidebar-backdrop');
             var topNav = document.querySelector('.for-machines-nav');
             var links = sidebar.querySelectorAll('a[data-section]');
-            var isMobile = function() { return window.innerWidth <= 768; };
+            var isMobile = function() { return window.innerWidth <= 1280; };
 
             function closeSidebar() {
                 sidebar.classList.remove('open', 'tab-open');

--- a/docs/for-researchers/index.html
+++ b/docs/for-researchers/index.html
@@ -1170,7 +1170,7 @@
         }
 
         /* Narrow desktop / tablet — hamburger menu for sidebar */
-        @media (max-width: 1100px) and (min-width: 769px) {
+        @media (max-width: 1280px) and (min-width: 769px) {
             .ft-sidebar {
                 width: 280px;
                 transform: translateX(-100%);
@@ -2072,7 +2072,7 @@
         var backdrop = document.getElementById('sidebar-backdrop');
         var topNav = document.querySelector('.ft-nav');
         var links = sidebar.querySelectorAll('a[data-section]');
-        var isMobile = function() { return window.innerWidth <= 768; };
+        var isMobile = function() { return window.innerWidth <= 1280; };
 
         function closeSidebar() {
             sidebar.classList.remove('open', 'tab-open');

--- a/docs/index.html
+++ b/docs/index.html
@@ -612,7 +612,7 @@
         const topNav = document.getElementById('top-nav');
         const sidebarEl = document.getElementById('sidebar');
         const header = document.querySelector('header');
-        const isMobile = () => window.innerWidth <= 768;
+        const isMobile = () => window.innerWidth <= 1280;
 
         const navObserver = new IntersectionObserver(entries => {
             entries.forEach(entry => {

--- a/docs/style.css
+++ b/docs/style.css
@@ -201,7 +201,7 @@ nav a:hover { color: var(--primary); }
     position: fixed;
     top: 0;
     left: 0;
-    width: 180px;
+    width: 220px;
     height: 100vh;
     overflow-y: auto;
     background: var(--bg-secondary);
@@ -2256,7 +2256,7 @@ html[data-theme="dark"] .theme-toggle:active .theme-switch-knob {
 
 /* Responsive */
 /* Narrow desktop / tablet — hamburger menu for sidebar */
-@media (max-width: 1100px) and (min-width: 769px) {
+@media (max-width: 1280px) and (min-width: 769px) {
     .sidebar {
         width: 280px;
         transform: translateX(-100%);


### PR DESCRIPTION
## Summary
- Restored sidebar width to 220px (reverts the too-narrow 180px change)
- Raised the sidebar-to-hamburger breakpoint from 1100px to 1280px across all pages
- Updated JS `isMobile` checks to match the new breakpoint

At 125% browser zoom, the effective viewport shrinks below the old 1100px threshold, causing the fixed sidebar overlay to cover main content. The higher breakpoint ensures the hamburger menu activates sooner.

## Test plan
- [ ] At 100% zoom on desktop (>1280px): sidebar overlay works as before
- [ ] At 125% zoom: hamburger menu activates instead of overlapping sidebar
- [ ] Mobile/tablet: no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)