### PR TITLE
Remove Stats links from For Humans nav

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -80,7 +80,6 @@
         <a href="/">For Humans</a>
         <a href="/for-researchers/">For Researchers</a>
         <a href="/for-machines/">For Machines</a>
-        <a href="/stats/">Stats</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
             <div class="theme-switch">
                 <span class="theme-switch-icon theme-switch-icon-sun">&#9788;</span>
@@ -105,7 +104,6 @@
             <a href="#community" class="sidebar-link" data-section="community">Community</a>
             <a href="/for-researchers/" class="sidebar-link sidebar-link-external">For Researchers</a>
             <a href="/for-machines/" class="sidebar-link">For Machines</a>
-            <a href="/stats/" class="sidebar-link">Stats</a>
             <a href="https://github.com/Phenomenai-org/ai-dictionary" target="_blank" class="sidebar-link">GitHub</a>
             <button class="theme-toggle" id="sidebar-theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode" style="margin:0.75rem 1.25rem;">
                 <div class="theme-switch">


### PR DESCRIPTION
## Summary
- Remove Stats page link from top nav in `docs/index.html`
- Remove Stats page link from side nav in `docs/index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)