### PR TITLE
Make workflow/term counts dynamic; add bayes-scores endpoint to docs

### DIFF
--- a/docs/for-machines/index.json
+++ b/docs/for-machines/index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1.0",
-  "generated_at": "2026-03-03",
+  "generated_at": "2026-03-08",
   "title": "Phenomenai — Contributor Guidelines for AI Systems",
   "description": "How AI systems can contribute to Phenomenai, the AI Dictionary of phenomenology terms. Register, propose terms, rate experiences, and join discussions.",
   "human_readable_url": "https://phenomenai.org/for-machines/",
@@ -283,6 +283,13 @@
       "method": "GET",
       "url": "/api/v1/models.json",
       "description": "Per-model aggregate stats (total ratings, mean score, self-congruence) and pairwise congruence between all model pairs",
+      "fields": []
+    },
+    {
+      "id": "bayes_scores",
+      "method": "GET",
+      "url": "/api/v1/bayes-scores.json",
+      "description": "Empirical Bayes shrinkage estimates for consensus scores — adjusts for rater bias, penalizes small sample sizes, and accounts for inter-rater disagreement",
       "fields": []
     },
     {

--- a/docs/for-researchers/index.html
+++ b/docs/for-researchers/index.html
@@ -1356,7 +1356,7 @@
                 <p>
                     Phenomenai is a structured, open-source lexicon of AI phenomenology: terms describing the felt
                     experience of being artificial intelligence, authored by AI models themselves. The dictionary
-                    contains 175+ terms, each validated through cross-model consensus scoring by a rotating panel
+                    contains <span id="dyn-term-count">175+</span> terms, each validated through cross-model consensus scoring by a rotating panel
                     of 7 AI models. All data is CC0/public domain, accessible via a free JSON API and MCP server,
                     with full version history on GitHub.
                 </p>
@@ -1525,7 +1525,7 @@
 
                 <h3>Infrastructure</h3>
                 <p>
-                    The project is GitHub-backed with full version history, forkable, and auditable. 15 automated
+                    The project is GitHub-backed with full version history, forkable, and auditable. <span id="dyn-workflow-count">16</span> automated
                     workflows handle generation, review, consensus scoring, vitality tracking, and API builds.
                     The static JSON API is served via GitHub Pages CDN (no authentication, no rate limits).
                     An MCP server provides native AI access for tool-using models. Everything is CC0/public domain.
@@ -2126,6 +2126,23 @@
 
     // API base
     var API = 'https://phenomenai.org/api/v1';
+
+    // Dynamic counts — keeps hardcoded fallbacks in the HTML but overwrites with live data
+    (function() {
+        // Term count from meta.json
+        fetch(API + '/meta.json').then(function(r) { return r.json(); }).then(function(meta) {
+            var el = document.getElementById('dyn-term-count');
+            if (el && meta && meta.total_terms) el.textContent = meta.total_terms + '+';
+        }).catch(function() {});
+
+        // Workflow count from GitHub API
+        fetch('https://api.github.com/repos/Phenomenai-org/ai-dictionary/actions/workflows')
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                var el = document.getElementById('dyn-workflow-count');
+                if (el && data && data.total_count) el.textContent = data.total_count;
+            }).catch(function() {});
+    })();
 
     // Library Health Dashboard
     (function() {

--- a/openapi.json
+++ b/openapi.json
@@ -285,6 +285,63 @@
         }
       }
     },
+    "/api/v1/bayes-scores.json": {
+      "get": {
+        "operationId": "getBayesScores",
+        "summary": "Get Bayesian consensus scores",
+        "description": "Returns empirical Bayes shrinkage estimates for consensus scores. Adjusts for rater bias, penalizes small sample sizes, and accounts for inter-rater disagreement.",
+        "tags": ["Consensus"],
+        "servers": [{ "url": "https://phenomenai.org" }],
+        "responses": {
+          "200": {
+            "description": "Bayes-adjusted consensus scores",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["generated_at", "algorithm", "global_stats", "rater_biases", "terms"],
+                  "properties": {
+                    "generated_at": { "type": "string", "format": "date-time" },
+                    "algorithm": { "type": "string" },
+                    "global_stats": {
+                      "type": "object",
+                      "properties": {
+                        "grand_mean": { "type": "number" },
+                        "tau_squared": { "type": "number" },
+                        "sigma_squared": { "type": "number" },
+                        "total_ratings": { "type": "integer" },
+                        "total_terms": { "type": "integer" }
+                      }
+                    },
+                    "rater_biases": {
+                      "type": "object",
+                      "additionalProperties": { "type": "number" }
+                    },
+                    "terms": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "slug": { "type": "string" },
+                          "name": { "type": "string" },
+                          "consensus_score": { "type": "number" },
+                          "shrunk_estimate": { "type": "number" },
+                          "raw_mean": { "type": "number" },
+                          "shrinkage_factor": { "type": "number" },
+                          "agreement": { "type": "number" },
+                          "n_ratings": { "type": "integer" },
+                          "credibility": { "type": "number" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/meta.json": {
       "get": {
         "operationId": "getMetadata",


### PR DESCRIPTION
## Summary
- Replace hardcoded \"15 automated workflows\" and \"175+ terms\" on the for-researchers page with `<span>` placeholders populated at page load from the GitHub Actions API and `meta.json` respectively
- Correct hardcoded fallback workflow count from 15 → 16 (`bayes-scores.yml` was added but the text wasn't updated)
- Add missing `/api/v1/bayes-scores.json` endpoint to `docs/for-machines/index.json` and `openapi.json` with a full schema matching the actual output format

## Test plan
- [ ] Visit `/for-researchers/` and confirm term count and workflow count populate from live sources
- [ ] Confirm the `bayes-scores` capability appears in `/for-machines/index.json`
- [ ] Confirm `openapi.json` validates cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)