### PR TITLE
Fix stats page sidebar nav responsive behavior

### DIFF
--- a/docs/stats/index.html
+++ b/docs/stats/index.html
@@ -97,6 +97,9 @@
         .ft-sidebar nav a:hover { color: var(--primary); background: var(--bg-tertiary); text-decoration: none; }
         .ft-sidebar nav a.active { color: var(--primary); border-left-color: var(--primary); background: var(--primary-light); font-weight: 600; }
         .ft-sidebar nav a.sidebar-sep { margin-top: 1rem; padding-top: 0.6rem; border-top: 1px solid var(--border); }
+        .ft-sidebar-tab {
+            display: none;
+        }
 
         /* Content */
         .ft-content { max-width: 1100px; margin: 0 auto; padding: 2rem; flex: 1; min-width: 0; }
@@ -212,9 +215,134 @@
             color: var(--text-secondary); font-size: 1.1rem;
         }
 
-        /* Responsive */
+        /* Hamburger */
+        .hamburger {
+            display: none;
+        }
+
+        /* Narrow desktop / tablet — hamburger menu for sidebar */
+        @media (max-width: 1280px) and (min-width: 769px) {
+            .ft-sidebar {
+                width: 280px;
+                transform: translateX(-100%);
+                transition: transform 0.25s ease, opacity 0.3s ease;
+                z-index: 200;
+                box-shadow: none;
+                opacity: 0;
+            }
+            .ft-sidebar.visible {
+                opacity: 0;
+                pointer-events: none;
+            }
+            .ft-sidebar.open {
+                transform: translateX(0);
+                box-shadow: 4px 0 20px rgba(0, 0, 0, 0.15);
+                opacity: 1;
+                pointer-events: auto;
+            }
+            .ft-sidebar-tab { display: none; }
+            .hamburger {
+                display: flex;
+                flex-direction: column;
+                gap: 5px;
+                position: fixed;
+                top: 12px;
+                left: 12px;
+                z-index: 201;
+                background: var(--bg);
+                border: 1px solid var(--border);
+                border-radius: var(--radius, 8px);
+                padding: 8px;
+                cursor: pointer;
+                box-shadow: 0 2px 8px var(--shadow);
+                opacity: 0.08;
+                transition: opacity 0.25s ease;
+            }
+            .hamburger.at-top {
+                opacity: 1;
+            }
+            .hamburger:hover,
+            .hamburger:focus-visible {
+                opacity: 1;
+            }
+            .hamburger span {
+                width: 20px;
+                height: 2px;
+                background: var(--text);
+                display: block;
+            }
+            .sidebar-backdrop {
+                position: fixed;
+                inset: 0;
+                background: rgba(0, 0, 0, 0.3);
+                z-index: 199;
+            }
+            .sidebar-backdrop.visible {
+                display: block;
+            }
+        }
+
+        /* Mobile */
         @media (max-width: 768px) {
             .ft-nav { display: none; }
+            .ft-sidebar {
+                width: 280px;
+                transform: translateX(-100%);
+                transition: transform 0.25s ease, opacity 0.3s ease;
+                z-index: 200;
+                box-shadow: none;
+                opacity: 0;
+            }
+            .ft-sidebar.visible {
+                /* On mobile, don't show the faded sidebar — only via hamburger */
+                opacity: 0;
+                pointer-events: none;
+            }
+            .ft-sidebar.open {
+                transform: translateX(0);
+                box-shadow: 4px 0 20px rgba(0, 0, 0, 0.15);
+                opacity: 1;
+                pointer-events: auto;
+            }
+            .sidebar-backdrop {
+                position: fixed;
+                inset: 0;
+                background: rgba(0, 0, 0, 0.3);
+                z-index: 199;
+            }
+            .sidebar-backdrop.visible {
+                display: block;
+            }
+            .hamburger {
+                display: flex;
+                flex-direction: column;
+                gap: 5px;
+                position: fixed;
+                top: 12px;
+                left: 12px;
+                z-index: 201;
+                background: var(--bg);
+                border: 1px solid var(--border);
+                border-radius: var(--radius, 8px);
+                padding: 8px;
+                cursor: pointer;
+                box-shadow: 0 2px 8px var(--shadow);
+                opacity: 0.08;
+                transition: opacity 0.25s ease;
+            }
+            .hamburger.at-top {
+                opacity: 1;
+            }
+            .hamburger:hover,
+            .hamburger:focus-visible {
+                opacity: 1;
+            }
+            .hamburger span {
+                width: 20px;
+                height: 2px;
+                background: var(--text);
+                display: block;
+            }
             .ft-content { padding: 1rem 1.25rem; }
             .ft-hero h1 { font-size: 1.5rem; }
             .stats-global { flex-direction: column; }
@@ -255,8 +383,9 @@
                 <a href="/for-machines/">For Machines</a>
                 <a href="https://github.com/Phenomenai-org/ai-dictionary" target="_blank">GitHub</a>
             </nav>
+            <div class="ft-sidebar-tab" aria-hidden="true">&#9654;</div>
         </aside>
-        <div class="ft-sidebar-backdrop" id="sidebar-backdrop"></div>
+        <div class="sidebar-backdrop" id="sidebar-backdrop"></div>
 
         <div class="ft-content">
             <section id="overview">
@@ -405,7 +534,7 @@
         // Nav fade + sidebar show on scroll
         var hero = document.querySelector('.ft-hero');
         if (hero) {
-            var isMobile = function() { return window.innerWidth <= 768; };
+            var isMobile = function() { return window.innerWidth <= 1280; };
             var navObserver = new IntersectionObserver(function(entries) {
                 entries.forEach(function(entry) {
                     if (isMobile()) return;


### PR DESCRIPTION
## Summary
- Align stats page sidebar with for-researchers page: add hamburger menu, tablet media query (1280px), mobile sidebar slide-in, backdrop overlay, and correct `isMobile` JS threshold
- Fix backdrop class name mismatch (`ft-sidebar-backdrop` → `sidebar-backdrop`)
- Add missing `ft-sidebar-tab` element and CSS

## Test plan
- [ ] Verify sidebar fades in on wide desktop when scrolling past hero
- [ ] Verify hamburger menu appears and works on tablet (769px–1280px)
- [ ] Verify hamburger menu appears and works on mobile (<768px)
- [ ] Compare behavior with for-researchers page — should match

🤖 Generated with [Claude Code](https://claude.com/claude-code)