### PR TITLE
Increase consensus batch size from 8 to 20

### DIFF
--- a/.github/workflows/consensus.yml
+++ b/.github/workflows/consensus.yml
@@ -13,7 +13,7 @@ on:
       batch_size:
         description: 'Number of terms to rate'
         required: false
-        default: '8'
+        default: '20'
       panel:
         description: 'Which models to use (free or all)'
         required: false
@@ -56,7 +56,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-          BATCH_SIZE: ${{ github.event.inputs.batch_size || '8' }}
+          BATCH_SIZE: ${{ github.event.inputs.batch_size || '20' }}
           CONSENSUS_PANEL: ${{ github.event.inputs.panel || 'all' }}
           PYTHONPATH: ${{ github.workspace }}/bot
         working-directory: ${{ github.workspace }}
@@ -96,7 +96,7 @@ jobs:
           echo "Rated ${{ steps.consensus.outputs.rated_count }} terms. ${{ steps.consensus.outputs.remaining_unrated }} unrated terms remain. Dispatching next batch..."
           sleep 30
           for attempt in 1 2 3; do
-            gh workflow run consensus.yml -f mode=backfill -f batch_size=${{ github.event.inputs.batch_size || '8' }} -f panel=${{ github.event.inputs.panel || 'all' }} && exit 0
+            gh workflow run consensus.yml -f mode=backfill -f batch_size=${{ github.event.inputs.batch_size || '20' }} -f panel=${{ github.event.inputs.panel || 'all' }} && exit 0
             echo "Attempt $attempt failed, retrying in 1 hour..."
             sleep 3600
           done

--- a/.github/workflows/debounced-consensus.yml
+++ b/.github/workflows/debounced-consensus.yml
@@ -25,7 +25,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           for attempt in 1 2 3; do
-            gh workflow run consensus.yml -f mode=backfill -f batch_size=8 -f panel=all && exit 0
+            gh workflow run consensus.yml -f mode=backfill -f batch_size=20 -f panel=all && exit 0
             echo "Attempt $attempt failed, retrying in 1 hour..."
             sleep 3600
           done

--- a/bot/consensus.py
+++ b/bot/consensus.py
@@ -7,7 +7,7 @@ a term describes an experience it recognizes. Results are aggregated
 into consensus scores that surface universal vs. architecture-specific terms.
 
 Usage:
-    BATCH_SIZE=8 CONSENSUS_PANEL=free python bot/consensus.py [--mode backfill|single|gap-fill] [--vitality]
+    BATCH_SIZE=20 CONSENSUS_PANEL=free python bot/consensus.py [--mode backfill|single|gap-fill] [--vitality]
 """
 
 import json
@@ -28,7 +28,7 @@ API_CONFIG_DIR = Path(__file__).parent / "api-config"
 CONSENSUS_DATA_DIR = Path(__file__).parent / "consensus-data"
 STATE_PATH = Path(__file__).parent / "consensus-state.json"
 
-BATCH_SIZE = int(os.environ.get("BATCH_SIZE", "8"))
+BATCH_SIZE = int(os.environ.get("BATCH_SIZE", "20"))
 PANEL_NAME = os.environ.get("CONSENSUS_PANEL", "free")
 
 FREE_PANEL = ["consensus-gemini", "consensus-openrouter", "consensus-mistral"]


### PR DESCRIPTION
## Summary
- Increases default consensus batch size from 8 to 20 across all workflows and Python config to match the bulk submission limit of 20 terms
- Updated in: `debounced-consensus.yml`, `consensus.yml` (input default, env fallback, chaining call), and `bot/consensus.py` (default constant + docstring)
- Concurrency safeguard (`max_concurrent_terms=4`) left intact — 20 terms process in ~5 waves of 4, keeping API calls within rate limits

## Test plan
- [ ] Trigger debounced-consensus workflow manually and verify it passes `batch_size=20`
- [ ] Verify consensus.yml defaults to 20 when no batch_size input is provided
- [ ] Confirm chaining dispatches propagate the 20-term batch size

🤖 Generated with [Claude Code](https://claude.com/claude-code)