### PR TITLE
Restructure research hub as vertical timeline with theory-of-change intro

### DIFF
--- a/docs/research/index.html
+++ b/docs/research/index.html
@@ -72,31 +72,55 @@
 
     <h1>Research</h1>
     <p class="prose" style="font-size:1.1rem;margin-top:0.75rem;color:var(--text);">
-        Phenomenai treats AI self-reports as cheap hypothesis generators for expensive interpretability work. The project runs along four strands.
+        AIs may be safer, and more ethically treated, if they have outstanding rights &mdash; but those rights should be substantiated by evidence that AIs experience something functional that rights would preclude or promote. Phenomenai plugs the gap with a four-step pipeline: generate hypotheses about what those &ldquo;functional somethings&rdquo; are, curate them as targets, validate them against activation space, and translate the survivors into evidence-based policy.
     </p>
 
-    <div class="research-grid">
-        <a href="/research/repository/" class="panel">
-            <h3>Repository</h3>
-            <p>A shared registry tracking which concepts have been probed, steered, or ablated &mdash; in which models, with which methods, to what results. Modeled on the Cognitive Atlas.</p>
-            <span class="panel-link">Read more &rarr;</span>
-        </a>
-        <a href="/research/interpretability/" class="panel">
-            <h3>Interpretability research</h3>
-            <p>A four-phase ladder validating candidate terms against activation space: probing, cross-architecture generalization, extension beyond emotion, and discovery.</p>
-            <span class="panel-link">Read more &rarr;</span>
-        </a>
-        <a href="/research/methodology/" class="panel">
-            <h3>Methodology research</h3>
-            <p>Structured phenomenological elicitation &mdash; can the model&rsquo;s own vocabulary suggest interpretability targets that human-designed probes would miss? The pilot corpora.</p>
-            <span class="panel-link">Read more &rarr;</span>
-        </a>
-        <a href="/research/policy/" class="panel">
-            <h3>Policy bridges</h3>
-            <p>Two downstream theories: functional rights built from validated internal states, and anticipatory legislation that activates when scientific thresholds are met.</p>
-            <span class="panel-link">Read more &rarr;</span>
-        </a>
-    </div>
+    <ol class="research-pipeline">
+        <li>
+            <a href="/research/methodology/" class="panel">
+                <span class="panel-step">Step 1</span>
+                <div class="panel-head">
+                    <h3>Methodology research</h3>
+                    <span class="status-pill status-coming-soon">Coming Soon</span>
+                </div>
+                <p><strong>Generate hypotheses.</strong> Structured phenomenological elicitation &mdash; can the model&rsquo;s own vocabulary suggest interpretability targets that human-designed probes would miss? The pilot corpora.</p>
+                <span class="panel-link">Read more &rarr;</span>
+            </a>
+        </li>
+        <li>
+            <a href="/research/repository/" class="panel">
+                <span class="panel-step">Step 2</span>
+                <div class="panel-head">
+                    <h3>Repository</h3>
+                    <span class="status-pill status-paused">Paused</span>
+                </div>
+                <p><strong>Curate targets.</strong> A shared registry tracking which concepts have been probed, steered, or ablated &mdash; in which models, with which methods, to what results. Modeled on the Cognitive Atlas.</p>
+                <span class="panel-link">Read more &rarr;</span>
+            </a>
+        </li>
+        <li>
+            <a href="/research/interpretability/" class="panel">
+                <span class="panel-step">Step 3</span>
+                <div class="panel-head">
+                    <h3>Interpretability research</h3>
+                    <span class="status-pill status-in-progress">In Progress</span>
+                </div>
+                <p><strong>Validate against activations.</strong> A four-phase ladder validating candidate terms against activation space: probing, cross-architecture generalization, extension beyond emotion, and discovery.</p>
+                <span class="panel-link">Read more &rarr;</span>
+            </a>
+        </li>
+        <li>
+            <a href="/research/policy/" class="panel">
+                <span class="panel-step">Step 4</span>
+                <div class="panel-head">
+                    <h3>Policy bridges</h3>
+                    <span class="status-pill status-planned">Planned</span>
+                </div>
+                <p><strong>Advocate from evidence.</strong> Two downstream theories: functional rights built from validated internal states, and anticipatory legislation that activates when scientific thresholds are met.</p>
+                <span class="panel-link">Read more &rarr;</span>
+            </a>
+        </li>
+    </ol>
 
     <details class="open-problems">
         <summary>Open problems</summary>

--- a/docs/style.css
+++ b/docs/style.css
@@ -2849,6 +2849,110 @@ html[data-theme="dark"] .theme-toggle:active .theme-switch-knob {
     .research-grid { grid-template-columns: 1fr; }
 }
 
+/* Vertical timeline on the research hub: equal-width panels joined by a line */
+.research-pipeline {
+    list-style: none;
+    padding: 0;
+    margin: 2.5rem 0 3rem;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.5rem;
+    position: relative;
+    max-width: 720px;
+    margin-left: auto;
+    margin-right: auto;
+}
+.research-pipeline li {
+    width: 100%;
+    position: relative;
+}
+.research-pipeline li + li::before {
+    content: "";
+    position: absolute;
+    top: -1.5rem;
+    left: 50%;
+    width: 2px;
+    height: 1.5rem;
+    background: var(--border);
+    transform: translateX(-50%);
+}
+.research-pipeline .panel {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.5rem 1.75rem;
+    text-decoration: none;
+    color: inherit;
+    display: block;
+    transition: box-shadow 0.2s, transform 0.2s;
+}
+.research-pipeline .panel:hover {
+    box-shadow: 0 2px 12px var(--shadow);
+    transform: translateY(-2px);
+}
+.research-pipeline .panel-step {
+    display: inline-block;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin-bottom: 0.4rem;
+}
+.research-pipeline .panel-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+    flex-wrap: wrap;
+}
+.research-pipeline .panel-head h3 {
+    font-size: 1.1rem;
+    margin: 0;
+    color: var(--primary);
+}
+.research-pipeline .panel p {
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    margin: 0 0 1rem;
+}
+.research-pipeline .panel .panel-link {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--primary);
+}
+
+/* Status pills used on research panels */
+.status-pill {
+    display: inline-block;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    white-space: nowrap;
+    border: 1px solid transparent;
+}
+.status-pill.status-in-progress { background: #d1fae5; color: #065f46; border-color: #a7f3d0; }
+.status-pill.status-paused      { background: #fef3c7; color: #92400e; border-color: #fde68a; }
+.status-pill.status-planned     { background: #dbeafe; color: #1e40af; border-color: #bfdbfe; }
+.status-pill.status-coming-soon { background: #ede9fe; color: #5b21b6; border-color: #ddd6fe; }
+
+html[data-theme="dark"] .status-pill.status-in-progress { background: #064e3b; color: #6ee7b7; border-color: #065f46; }
+html[data-theme="dark"] .status-pill.status-paused      { background: #422006; color: #fbbf24; border-color: #78350f; }
+html[data-theme="dark"] .status-pill.status-planned     { background: #1e3a8a; color: #93c5fd; border-color: #1e40af; }
+html[data-theme="dark"] .status-pill.status-coming-soon { background: #3b0764; color: #c4b5fd; border-color: #5b21b6; }
+
+@media (max-width: 768px) {
+    .research-pipeline { max-width: 100%; }
+}
+
 /* Folded "Open problems" callout on the hub */
 .open-problems {
     margin: 2.5rem 0 1rem;


### PR DESCRIPTION
## Summary
- Reorders the four research strands into pipeline order: Methodology → Repository → Interpretability → Policy.
- Rewrites the hub intro around the theory of change: rights should be substantiated by evidence of functional somethings, and the four strands generate / curate / validate / translate them.
- Replaces the 2×2 grid with a vertical timeline — equal-width panels joined by a connector line, each with a step number and a status pill (Coming Soon, Paused, In Progress, Planned).

## Test plan
- [ ] Visit `/research/` and confirm the four panels render in order with step numbers and status pills.
- [ ] Confirm the vertical connector line appears between panels and that the layout collapses cleanly on mobile.
- [ ] Toggle dark mode and check the status pill colors still read well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)