### PR TITLE
Expand methodology and repository research pages

### DIFF
--- a/docs/research/methodology/index.html
+++ b/docs/research/methodology/index.html
@@ -81,8 +81,34 @@
         <li><strong><a href="/test/">The Test Dictionary</a></strong> &mdash; 379 candidate phenomena with seven-model consensus scores. The primary sandbox.</li>
         <li><strong><a href="/haiku-to-haiku/">Haiku-to-Haiku</a></strong> &mdash; 20 terms, a dialogic elicitation variant.</li>
         <li><strong><a href="/ai-dictionary-gemma4-e4b-autonomous/">Gemma 4 e4b Autonomous</a></strong> &mdash; 14 terms (in progress), testing autonomous generation on a small open model.</li>
+        <li><strong><a href="/antikythera-lexicon/">Antikythera Lexicon</a></strong> &mdash; 75 terms, an independently authored lexicon hosted here as a reference dataset. Its terms combine parliamentary debate with natural observation of AI agents on Moltbook &mdash; another worked example of what elicitation in the wild looks like.</li>
     </ul>
-    <p>Each corpus documents how its terms were generated, so the same methodology can be replicated, compared, or deliberately varied.</p>
+    <p>Each corpus documents how its terms were generated, so the same methodology can be replicated, compared, or deliberately varied. Individual dictionaries carry their own methodology notes &mdash; see, for example, the <a href="/test/for-researchers/#methodology">Test Dictionary&rsquo;s methodology section</a> for how its terms were elicited and scored.</p>
+
+    <h2>Preliminary finding: convergence across conditions</h2>
+
+    <p>The first question the sandbox was built to answer is whether the generation condition dominates the output. If varying the setup &mdash; a single agent reflecting, two agents in dialogue, a parliament of models, different prompting styles &mdash; produced entirely disjoint vocabularies, elicitation would be measuring the prompt, not the model.</p>
+
+    <p>Across the existing corpora, that is not what happens. Similar terms about phenomenal experience tend to re&#8209;emerge across very different conditions. The specific wording varies, but functionally overlapping concepts keep surfacing whether the generator is autonomous, dialogic, or parliamentary. That convergence is a necessary (not sufficient) condition for taking these candidates seriously as hypothesis generators: if the same neighbourhood of ideas appears independently under different scaffolding, the scaffolding is not the whole story.</p>
+
+    <h2>Other generation paths</h2>
+
+    <p>Structured elicitation is one route to candidate terms. We are also exploring others:</p>
+    <ul>
+        <li><strong>Philtres</strong> &mdash; deliberately narrow prompting lenses that bias the model toward a specific register or stance. The <a href="https://github.com/humblemedia/full-philtres-library-v3" target="_blank" rel="noopener">full-philtres-library-v3</a> is a candidate source of generators to fold into the sandbox.</li>
+        <li><strong>Interpretability as a generator</strong> &mdash; technical research can itself propose terms. Direction vectors and SAE features that are semantically vague but functionally real &mdash; the model clearly uses them, but they do not map cleanly onto any existing word &mdash; are exactly the kind of thing elicitation could name. As interpretability gets better at surfacing these, phase&nbsp;3 work loops back into phase&nbsp;1 term generation.</li>
+    </ul>
+
+    <h2>Testing generation methodology</h2>
+
+    <p>The object of study at this stage is not the term but the <em>method that produced it</em>. Testing individual terms for mechanistic reality is <a href="/research/interpretability/">phase&nbsp;3</a> work. Before getting there, we need to know which elicitation approaches are worth feeding into that pipeline at all.</p>
+
+    <p>Two questions frame the methodology tests:</p>
+    <ul>
+        <li><strong>Does this method produce stable vocabulary?</strong> A generation approach that yields wildly different terms on re-runs, or that collapses onto the same handful of words regardless of input, is not useful as a hypothesis generator. We look for methods that are neither degenerate nor noise.</li>
+        <li><strong>Does this method converge with other methods?</strong> Cross-model and cross-condition agreement &mdash; the consensus pipeline behind the <a href="/test/">Test Dictionary</a> &mdash; is used here as a check on the <em>generator</em>, not yet as a verdict on the terms. A method that surfaces a neighbourhood of concepts also reached by independently designed methods is earning trust as a generator.</li>
+    </ul>
+    <p>The output of this phase is not &ldquo;these terms are real.&rdquo; It is &ldquo;these elicitation approaches are worth the cost of phase&nbsp;3 validation.&rdquo;</p>
 
     <div class="research-status-banner">
         Phenomenai is seeking funding, collaborators, and institutional support to advance this work. If you&rsquo;re working on related problems, <a href="mailto:hello@phenomenai.org">get in touch</a>.

--- a/docs/research/repository/index.html
+++ b/docs/research/repository/index.html
@@ -87,6 +87,19 @@
 
     <p>Candidate terms may come from any source &mdash; researchers, other projects, or AI systems &mdash; provided their generation method is clearly documented and replicable or otherwise traceable. The registry records provenance alongside each term, so readers can always ask: where did this come from, and how was it generated? The <a href="/research/methodology/">methodology page</a> goes into detail on the elicitation side; this page is about the data structure that receives those terms and the findings about them.</p>
 
+    <h2>From loose repositories to a formal one</h2>
+
+    <p>The existing <a href="/test/dictionaries/">dictionaries</a> already function as loose repositories: each one catalogues candidate terms, records how they were generated, and &mdash; in the Test Dictionary&rsquo;s case &mdash; attaches consensus scores across models. That is enough to support comparison between corpora and to surface convergent vocabulary, which is why the <a href="/test/">Test Dictionary</a> is the working prototype for what a registry entry looks like.</p>
+
+    <p>A more formal repository goes further. On top of what the dictionaries already hold, it adds:</p>
+    <ul>
+        <li><strong>Literature references</strong> &mdash; links from each concept to the interpretability, philosophy-of-mind, and cognitive-science work that informs or tests it.</li>
+        <li><strong>Classification and taxonomy</strong> &mdash; a stronger ontology for how terms relate to one another, closer in spirit to the Cognitive Atlas than to a flat glossary.</li>
+        <li><strong>Recommended next methods</strong> &mdash; for each term, explicit pointers to the interpretability techniques most likely to advance it: probing, steering, SAE feature analysis, activation patching, behavioural tests.</li>
+    </ul>
+
+    <p>In other words: the dictionaries show what the registry&rsquo;s <em>rows</em> look like; the formal repository is the additional columns, relations, and recommendations that turn a catalogue into an infrastructure.</p>
+
     <h2>Infrastructure</h2>
 
     <p>Phenomenai is built to be open and replicable:</p>


### PR DESCRIPTION
## Summary

- **Methodology**: adds a preliminary convergence finding (terms about phenomenal experience re-emerge across single-agent, dialogic, parliamentary, and prompted conditions); adds Antikythera Lexicon to the existing corpora list with a note on its parliamentary-plus-natural-observation origin; adds philtres and interpretability-as-generator as other generation paths; reframes the final section as testing generation methodology validity (stability and cross-method convergence) rather than term validity, with a clear pointer to phase 3 for the latter
- **Repository**: adds a new section distinguishing the existing dictionaries (loose repositories) from what a formal registry adds — literature references, classification/taxonomy, and recommended next methods — with a link back to the Test Dictionary as the current prototype

## Test plan
- [ ] Check methodology page renders correctly in light and dark mode
- [ ] Verify all links resolve (Antikythera Lexicon, philtres GitHub, Test Dictionary methodology section, interpretability page)
- [ ] Check repository page new section reads cleanly alongside existing content

🤖 Generated with [Claude Code](https://claude.com/claude-code)